### PR TITLE
feat: dynamic budget reallocation via Utilization Velocity Index (UVI)

### DIFF
--- a/PHASE7_PLAN.md
+++ b/PHASE7_PLAN.md
@@ -1,0 +1,198 @@
+# Phase 7 Plan: Dynamic Budget Reallocation via Utilization Velocity Index (UVI)
+
+## Goal
+Shift the budget auditor from a **static daily USD ceiling** to a **dynamic pressure signal** based on how fast each OAuth provider is burning through its real reset-window quota relative to how much of that window remains. UVI is then consumed by the selector to:
+- **Tax** providers trending toward premature exhaustion (UVI > 1.0).
+- **Unlock** premium providers for standard tasks when surplus is detected near the end of a reset cycle.
+
+## Core Concept
+
+```
+UVI = consumed_fraction / elapsed_fraction_of_window
+```
+
+- `UVI ≈ 1.0` → on-pace
+- `UVI > 1.0` → burning faster than safe → **tax** (deprioritize for non-essential calls)
+- `UVI < 1.0` → underutilized → **unlock** for non-premium tiers
+
+Thresholds (configurable):
+- `UVI > 1.5` → **stressed** — only pick when tier strictly requires this provider
+- `UVI > 2.0` → **critical** — treat like over-budget (skip unless last-resort fallback)
+- `UVI < 0.5` AND `elapsedFraction > 0.7` → **surplus** — eligible for promotion to lower tiers
+
+## Key Pivot from v1 of this Plan
+
+**Old idea:** parse rate-limit response headers from each completed request + a config-declared token cap.
+
+**New idea (from `pi-usage-bars/core.ts`):** call each provider's actual OAuth usage endpoint directly. Those endpoints *already* return `used_percent` and `resets_at` — exactly the inputs UVI needs. No header plumbing, no config caps.
+
+This means:
+- We don't need to expose response headers through the streaming SDK layer (was Open Question #1 in v1).
+- We don't need users to declare token caps (was Open Question #2).
+- "Active polling" is no longer a Phase 7.1 deferral — it's the primary path.
+
+## Reference Implementation Analysis
+
+`pi-usage-bars/extensions/usage-bars/core.ts` already implements:
+
+| Provider | Endpoint | Auth | Window data |
+|---|---|---|---|
+| `openai-codex` | `chatgpt.com/backend-api/wham/usage` | OAuth `Bearer` | `primary_window` (5h) + `secondary_window` (7d) with `used_percent` and `reset_after_seconds` |
+| `anthropic` | `api.anthropic.com/api/oauth/usage` (header `anthropic-beta: oauth-2025-04-20`) | OAuth `Bearer` | `five_hour.{utilization,resets_at}`, `seven_day.{utilization,resets_at}`, plus `extra_usage.{used_credits,monthly_limit}` for credit overage |
+| `google-gemini-cli` | `cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota` POST | OAuth `Bearer` + `projectId` discovered via `:loadCodeAssist` | bucket-shaped `[{ tokenType, modelId, remainingFraction }]`; usage-bars picks the most-used REQUESTS bucket (gemini-pro primary, gemini-flash secondary) |
+| `google-antigravity` | same Google endpoint | same | same buckets, but primary is `claude` non-thinking → fallback to gemini-pro → flash |
+
+Also provides for free:
+- Token refresh via `@mariozechner/pi-ai`'s `getOAuthApiKey()` — handles token expiry transparently and persists back to `~/.pi/agent/auth.json`.
+- 429 handling: `retry-after` parsing, exponential backoff (2m → 30m capped), persisted cooldown state, stale-cache fallback so we still have *some* signal during cooldown.
+- File-locked cache (`~/.pi/usage-bars-cache.json` or tmpdir variant) to prevent concurrent processes from hammering the endpoints.
+
+## Decision: Reuse vs. Vendor vs. Re-implement
+
+Three options:
+
+**A. Add `pi-usage-bars` (or a sub-package of it) as a dependency.**  
+Cleanest. Risk: it's a single-author repo and may not publish a library entrypoint — would need to confirm. The file is in `extensions/usage-bars/` which suggests it's structured as a Pi extension, not a published lib.
+
+**B. Vendor `core.ts` into `src/quota-fetcher.ts`.**  
+Copy the file (with attribution), strip the parts we don't need (z.ai, the formatting helpers used by the bar UI), and treat it as our own module. Pro: zero coupling, full control. Con: stale upstream when providers change endpoints.
+
+**C. Re-implement from scratch using usage-bars as a spec.**  
+Pointless given (B) is just `cp` + edits.
+
+**Proposal:** **Option B**, vendor it. Concretely: import the necessary functions verbatim into `src/quota-fetcher.ts` with a header comment crediting `ajarellanod/pi-usage-bars`. Keep the surface small: `fetchAllUsages()`, `fetchClaudeUsageWithFallback()`, `fetchCodexUsage()`, `fetchGoogleUsage()`, plus the auth-refresh helper. Drop z.ai bits since we don't use it.
+
+## File-by-File Changes
+
+### `src/types.ts`
+- `QuotaWindow`:
+  ```ts
+  type QuotaWindow = {
+    provider: string;             // e.g. "anthropic", "openai-codex"
+    scope: "session" | "weekly" | "monthly";
+    usedPercent: number;          // 0–100
+    resetsAt?: string;            // ISO timestamp when known
+    resetsInSec?: number;         // alternative when only relative time provided (codex)
+    windowDurationMs: number;     // 5h, 7d, etc — needed to compute elapsedFraction
+    source: "oauth-usage" | "stale-cache";
+    fetchedAt: number;
+  };
+  ```
+- `UtilizationSnapshot`:
+  ```ts
+  type UtilizationSnapshot = {
+    provider: string;
+    uvi: number;                  // worst-window UVI
+    status: "ok" | "surplus" | "stressed" | "critical";
+    windows: QuotaWindow[];
+    reason: string;
+    error?: string;               // populated when fetch failed
+    stale?: boolean;
+  };
+  ```
+- Extend `BudgetState` with `utilization?: Record<string, UtilizationSnapshot>`.
+
+### `src/quota-fetcher.ts` (new — vendored from pi-usage-bars)
+- Functions imported (lightly trimmed, attribution comment):
+  - `readAuth`, `writeAuth`, `ensureFreshAuthForProviders`
+  - `fetchCodexUsage(token, config)` → returns `{ session, weekly, sessionResetsIn, weeklyResetsIn }`
+  - `fetchClaudeUsageWithFallback(config)` → handles 429 cache + auto refresh
+  - `fetchGoogleUsage(token, endpoint, projectId, "gemini"|"antigravity", config)` + `discoverGoogleProjectId`
+  - `fetchAllUsages(config)` orchestration
+- Adapter layer to convert pi-usage-bars `UsageData` → our `QuotaWindow[]`:
+  - Codex: `[{ scope:"session", windowDurationMs: 5h }, { scope:"weekly", windowDurationMs: 7d }]`
+  - Claude: same two windows + optional `monthly` from `extra_usage`
+  - Gemini/Antigravity: model returns aggregate %; treat as a single window with `windowDurationMs: 24h` (Google's quotas reset daily; confirm vs. the buckets — open question)
+- **Window duration constants** to be confirmed empirically:
+  - Codex: `primary_window = 5h`, `secondary_window = 7d` (per the code's reset_after_seconds)
+  - Claude: `five_hour = 5h`, `seven_day = 7d` (clear from field names)
+  - Google: TBD — buckets don't expose duration; we may have to assume daily
+
+### `src/uvi.ts` (new — pure math, no I/O)
+- `computeUVI(window: QuotaWindow, now: number): number`
+  - `consumedFraction = window.usedPercent / 100`
+  - `elapsedFraction = 1 - max(0, (resetTime - now) / windowDurationMs)`
+  - `return consumedFraction / max(elapsedFraction, ε)` — clamp ε to e.g. 0.05 to avoid div-by-zero at window start
+- `classifyUVI(uvi: number, elapsedFraction: number): UVIStatus`
+  - Surplus requires both `elapsedFraction > 0.7` and `uvi < 0.5`.
+- `aggregateProviderUVI(windows: QuotaWindow[], now: number): UtilizationSnapshot`
+  - Worst-window dominates. Reason string lists the dominant window.
+
+### `src/quota-cache.ts` (new — thin layer over pi-usage-bars cache file)
+- We re-use the existing `~/.pi/agent/extensions/auto-router.stats.json`-adjacent file or simply piggyback on the usage-bars cache (`~/.pi/usage-bars-cache.json` if present, falling back to our own).
+- Refresh policy:
+  - In-memory cached snapshot, default TTL **60s** (configurable via env `AUTO_ROUTER_UVI_TTL_MS`).
+  - Hard floor of **30s** between calls per provider.
+  - On 429: respect retry-after / exponential backoff (already implemented in the vendored code).
+- Async refresh kickoff at the start of `streamAutoRouter()` if cache is stale, but **do not block**: route uses last-known UVI; new value lands for the next call. (Avoids adding latency to every prompt.)
+
+### `src/budget-tracker.ts`
+- Add a small `setUtilization(provider, snapshot)` setter so `getBudgetState()` returns it alongside spend.
+- Keep static USD limits intact — UVI augments, doesn't replace them. (Critical for backward compat.)
+
+### `src/budget-auditor.ts`
+- Extend `BudgetAuditResult` with `uvi?: number`, `utilizationStatus?: UVIStatus`, and a `hint?: "promote" | "demote"`.
+- New status precedence:
+  - UVI `critical` OR USD-blocked → `status: "blocked"`
+  - UVI `stressed` OR USD-warning → `status: "warning"` + `hint: "demote"`
+  - UVI `surplus` → `status: "ok"` + `hint: "promote"`
+  - else → unchanged.
+
+### Selector integration in `index.ts` (`streamAutoRouter`)
+- After `auditBudget` produces hints, partition `auditedCandidates` into `{ promoted, normal, taxed }`.
+- Selection rule:
+  - For the requested tier, prefer `promoted` ordering ahead of `normal`, `taxed` last.
+  - For non-premium tiers (e.g. `economy`, `swe`), if the route's first target is a premium provider in `promoted`, allow it to be picked over a cheaper default (this is the "unlock premium for standard tasks" behavior from the proposal).
+  - Never select `taxed` unless it's the only remaining option — same semantics as today's "constraint fallback".
+- Kick the cache refresher (`refreshUtilizationsAsync()`) at the top of `streamAutoRouter` so subsequent calls have fresh data.
+
+### Config surface
+- Optional global config block (in routes JSON or env), all defaults sensible:
+  ```jsonc
+  "uvi": {
+    "enabled": true,
+    "ttlMs": 60000,
+    "thresholds": { "stressed": 1.5, "critical": 2.0, "surplus": 0.5 },
+    "surplusMinElapsed": 0.7
+  }
+  ```
+- Backward compatible: missing block → defaults; UVI disabled → behaves exactly like today.
+
+### UI / commands
+- `/auto-router budget` extended with a UVI table:
+  ```
+  Provider          USD spend / limit     UVI    Status      Window
+  anthropic         —                     1.73   stressed    5h@72%, 7d@40%
+  openai-codex      —                     0.42   surplus     5h@10%, 7d@28%, 6d6h elapsed
+  google-antigravity —                    0.95   ok          daily@31%
+  ```
+- `/auto-router explain` includes UVI in the rationale string.
+- Status line gains a `uvi:` segment when any provider is `stressed` or `critical`.
+- New `/auto-router uvi [refresh|show]` command for forcing a refresh & inspecting raw fetch results.
+
+### Tests
+- `tests/uvi.test.ts` — pure math: on-pace, stressed, critical, surplus-only-late, ε clamping.
+- `tests/quota-fetcher.test.ts` — adapters from `UsageData` → `QuotaWindow[]` (mock the fetch fn, snapshot common payloads from each provider).
+- `tests/budget-auditor.test.ts` — extend with UVI-driven status transitions and hint emission.
+- `tests/budget-tracker.test.ts` — extend with utilization setter/getter.
+- Integration test: candidate ordering with mixed UVI inputs feeding the selector.
+
+## Open Questions (need your input before coding)
+
+1. **Vendor or depend?** Is `pi-usage-bars` published anywhere installable, or do we vendor `core.ts` (with attribution) into `src/quota-fetcher.ts`? My recommendation: vendor.
+2. **Google window duration.** The Google quota endpoint returns `remainingFraction` per bucket but doesn't expose the reset window length. Default assumption: daily (24h) — but worth confirming. If wrong, UVI for Google will be miscalibrated.
+3. **Refresh on every request vs. async?** Sync fetch adds 100–500 ms per provider; async means UVI lags by one prompt. I lean async with a TTL of ~60s, but if you'd rather have always-fresh data, we trade off latency.
+4. **Promotion aggression.** "Surplus → unlock premium on lower tiers": should this be a hard override (always pick the surplus premium target) or only as a tiebreaker? My default: tiebreaker only, with an env flag for hard override.
+5. **Auth file location coupling.** pi-usage-bars reads `~/.pi/agent/auth.json` and refreshes tokens in place via `@mariozechner/pi-ai`. Are we OK with auto-router writing to that shared file, or do we want an opt-in (e.g. `AUTO_ROUTER_REFRESH_AUTH=1`)?
+6. **Provider name mapping.** Routes config uses provider names like `claude-agent-sdk` and `google-antigravity`; usage endpoints are keyed `anthropic` / `openai-codex` / `google-gemini-cli` / `google-antigravity`. We need a mapping table — straightforward but worth calling out.
+
+## Suggested Increments (review checkpoints)
+
+- **Step 1 — Pure UVI math.** `src/types.ts` additions + `src/uvi.ts` + `tests/uvi.test.ts`. No I/O, mergeable on its own. Self-contained, low-risk.
+- **Step 2 — Vendor quota-fetcher.** Bring in `src/quota-fetcher.ts` from pi-usage-bars (trimmed) + tests with mocked fetch. No integration with router yet.
+- **Step 3 — Cache layer + provider mapping.** `src/quota-cache.ts` with TTL, async refresh, mapping table from route-provider-id → oauth-provider-id.
+- **Step 4 — Auditor + selector wiring.** Hooks into `streamAutoRouter`, with a feature flag (`AUTO_ROUTER_UVI=1`) so we can ship dark and validate.
+- **Step 5 — UI surfacing.** `/auto-router budget`, `/auto-router uvi`, status line, `explain` rationale.
+- **Step 6 — Promote out of dark mode.** Flip the default to enabled, update PROPOSAL.md to mark Phase 7 UVI complete.
+
+Ready to commit to this revised shape? If yes, I'll start on Step 1.

--- a/PROPOSAL.md
+++ b/PROPOSAL.md
@@ -179,14 +179,16 @@ type ContextClassification = 'short' | 'medium' | 'long' | 'epic';
 - [x] Budget warnings at thresholds
 - [x] Route summary showing target health and auth status
 
-### Phase 7: ⬜ Advanced Features (Future)
+### Phase 7: 🟡 Advanced Features (Partial)
 - [ ] Performance-based ranking (track latency per provider)
 - [ ] Intent classification (code vs creative vs analysis)
-- [ ] **Dynamic budget reallocation (Utilization Velocity Index)**:
-    - Shift from static USD limits to real-time quota pressure sensing by polling status from OAuth providers (Claude, Gemini, etc.).
-    - Implement a **Utilization Velocity Index (UVI)** that compares consumed quota percentage against the time remaining in the reset window.
-    - Automatically "tax" high-tier models when they are trending toward premature exhaustion (e.g., 25% used with 85% of the week remaining).
-    - "Unlock" premium models for standard tasks when a surplus is detected near the end of a reset cycle.
+- [x] **Dynamic budget reallocation (Utilization Velocity Index)** — see §9
+    - Polls OAuth usage endpoints for Anthropic, OpenAI Codex, Google Gemini, and Google Antigravity (vendored from `ajarellanod/pi-usage-bars`).
+    - Computes UVI = consumed_fraction / elapsed_fraction_of_window per quota window, takes the worst across windows.
+    - Taxes (deprioritizes) providers with `UVI ≥ 1.5` (stressed) and blocks at `UVI ≥ 2.0` (critical).
+    - Promotes premium providers when `UVI ≤ 0.5` near the end of the reset window (`elapsed ≥ 0.7`).
+    - Surfaced via `/auto-router uvi` and integrated into `/auto-router budget`, the status line, and `explain` reasoning.
+    - Off by default; opt in with `AUTO_ROUTER_UVI=1` or `/auto-router uvi enable`.
 - [ ] Provider health checks (proactive ping)
 - [ ] User feedback loop (`/auto-router rate <good|bad> [reason]`)
 
@@ -259,15 +261,60 @@ streamAutoRouter()
 
 ```
 index.ts                          — Extension entry point, provider registration, streamAutoRouter, tryTarget, sanitizeContext, UI commands
-src/types.ts                      — All type definitions
+src/types.ts                      — All type definitions (incl. QuotaWindow, UtilizationSnapshot, UVIThresholds)
 src/context-analyzer.ts           — Token estimation, history depth, classification
 src/constraint-solver.ts          — Target filtering by capability requirements
-src/budget-tracker.ts             — Daily spend tracking, limits, persistence
-src/budget-auditor.ts             — Budget constraint rule
+src/budget-tracker.ts             — Daily spend tracking, limits, persistence, utilization snapshots
+src/budget-auditor.ts             — Budget + UVI constraint rule (emits promote/demote hints)
 src/policy-engine.ts              — Pipeline orchestrator (skeleton, integrated into index.ts)
 src/shortcut-parser.ts            — @ shortcut parsing, registry
+src/uvi.ts                        — Pure UVI math (computeUVI, classifyUVI, aggregateProviderUVI)
+src/quota-fetcher.ts              — OAuth usage endpoints + adapter to QuotaWindow[] (vendored from ajarellanod/pi-usage-bars)
+src/quota-cache.ts                — TTL-bounded async refresh of utilization snapshots, route→OAuth provider mapping
 tests/                            — Unit tests for all modules
 ```
+
+## 9. Dynamic Budget Reallocation (UVI)
+
+### Overview
+The auto-router can sense real-time quota pressure on each OAuth subscription provider and reorder candidates accordingly, rather than relying solely on static USD limits.
+
+### How it works
+1. `QuotaCache` polls each provider's OAuth usage endpoint via `fetchAllUsages()` (vendored from `pi-usage-bars`):
+   - Anthropic: `api.anthropic.com/api/oauth/usage` (5-hour + 7-day windows)
+   - OpenAI Codex: `chatgpt.com/backend-api/wham/usage` (5-hour + 7-day windows)
+   - Google Gemini / Antigravity: `cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota` (daily window)
+2. Each `UsageData` is converted to `QuotaWindow[]` and aggregated into a `UtilizationSnapshot` per provider.
+3. `BudgetTracker.setUtilization()` plumbs snapshots into `BudgetState.utilization`.
+4. `auditBudget()` consults UVI alongside USD spend:
+   - `UVI ≥ 2.0` → `blocked` (treated like over-budget)
+   - `UVI ≥ 1.5` → `warning` + `hint: "demote"`
+   - `UVI ≤ 0.5` and `elapsed ≥ 0.7` → `ok` + `hint: "promote"`
+5. `streamAutoRouter` partitions audited candidates into `[promoted, normal, demoted]` and tries them in that order.
+
+### Refresh policy
+- Async, non-blocking refresh on each prompt; never adds latency.
+- TTL: 60s (override via `AUTO_ROUTER_UVI_TTL_MS`).
+- Hard floor of 30s between refreshes per provider.
+- Token refresh handled by `@mariozechner/pi-ai`'s `getOAuthApiKey()`.
+
+### Configuration
+- `AUTO_ROUTER_UVI=1` to enable (off by default).
+- `AUTO_ROUTER_UVI_TTL_MS=<ms>` to override TTL.
+- `/auto-router uvi enable|disable|show|refresh` for runtime control.
+
+### Surfaces
+- `/auto-router budget` includes a UVI block per provider.
+- `/auto-router explain` reasoning includes promote/demote notes.
+- Status line gains a `uvi: provider=N.NN stressed` segment when any provider is `stressed`/`critical`.
+
+### Provider name mapping
+`auditBudget` keys by route-config provider name. The cache re-keys snapshots so `claude-agent-sdk` resolves to the `anthropic` snapshot. Other providers (`openai-codex`, `google-gemini-cli`, `google-antigravity`) match 1:1.
+
+### Limitations
+- Google's `retrieveUserQuota` does not expose its window duration; we assume 24h.
+- Snapshot only updates on the prompt *after* a successful refresh (TTL design).
+- Static USD limits still apply on top of UVI — UVI augments rather than replaces.
 
 ## 8. Success Metrics
 

--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,8 @@ import { DEFAULT_SHORTCUTS, listShortcuts, parseShortcut } from "./src/shortcut-
 import { inferRequirements, solveConstraints, type CapabilityMap, type ConstraintRequirements } from "./src/constraint-solver.ts";
 import { BudgetTracker, todayKey } from "./src/budget-tracker.ts";
 import { auditBudget } from "./src/budget-auditor.ts";
-import type { RoutingDecision, Tier, Message as RoutingMessage } from "./src/types.ts";
+import { QuotaCache, mapRouteProviderToOAuth } from "./src/quota-cache.ts";
+import type { RoutingDecision, Tier, Message as RoutingMessage, UtilizationSnapshot } from "./src/types.ts";
 
 const PROVIDER_ID = "auto-router";
 const AUTH_PATH = join(homedir(), ".pi", "agent", "auth.json");
@@ -59,8 +60,35 @@ const lastDecisionByRoute = new Map<string, RoutingDecision>();
 const lastShortcutByRoute = new Map<string, { shortcut: string; tier: Tier }>();
 const lastBudgetWarningByRoute = new Map<string, string>();
 const budgetTracker = new BudgetTracker();
+const quotaCache = new QuotaCache();
 let budgetReady = false;
 let latestUiContext: any;
+
+function syncUtilizationIntoBudget(): void {
+  if (!quotaCache.isEnabled()) return;
+  const snapshots = quotaCache.getAllSnapshots();
+  // Re-key snapshots by route-config provider names so auditBudget(provider) lookups work.
+  const remapped: Record<string, UtilizationSnapshot> = {};
+  for (const [oauthId, snap] of Object.entries(snapshots)) {
+    remapped[oauthId] = snap;
+    if (oauthId === "anthropic") remapped["claude-agent-sdk"] = snap;
+  }
+  budgetTracker.setUtilization(remapped);
+}
+
+function formatUtilizationLines(cache: QuotaCache): string[] {
+  const snapshots = cache.getAllSnapshots();
+  const entries = Object.entries(snapshots);
+  if (entries.length === 0) return [];
+  return entries.map(([provider, snap]) => {
+    const winSummary = snap.windows.length > 0
+      ? snap.windows.map((w) => `${w.scope}@${w.usedPercent.toFixed(0)}%`).join(", ")
+      : "no windows";
+    const staleTag = snap.stale ? " [stale]" : "";
+    const errTag = snap.error ? ` [err: ${snap.error}]` : "";
+    return `  ${provider.padEnd(22)} UVI=${snap.uvi.toFixed(2).padStart(5)} ${snap.status.padEnd(8)} | ${winSummary}${staleTag}${errTag}`;
+  });
+}
 
 async function ensureBudgetLoaded(): Promise<void> {
   if (budgetReady) return;
@@ -712,6 +740,8 @@ function streamAutoRouter(model: Model<Api>, context: Context, options?: SimpleS
     try {
       loadRoutesConfig();
       await ensureBudgetLoaded();
+      quotaCache.refreshIfStale();
+      syncUtilizationIntoBudget();
 
       const userMsg = extractLastUserText(context);
       const match = userMsg ? parseShortcut(userMsg.text) : null;
@@ -749,6 +779,9 @@ function streamAutoRouter(model: Model<Api>, context: Context, options?: SimpleS
       const auditedRejections: string[] = [];
       const budgetWarnings: string[] = [];
       const auditedCandidates: RouteTarget[] = [];
+      const promotedCandidates: RouteTarget[] = [];
+      const demotedCandidates: RouteTarget[] = [];
+      const uviNotes: string[] = [];
       for (const cand of solved.candidates) {
         const audit = auditBudget(cand.provider, budgetState);
         if (audit.status === "blocked") {
@@ -758,14 +791,23 @@ function streamAutoRouter(model: Model<Api>, context: Context, options?: SimpleS
         if (audit.status === "warning" && audit.message) {
           budgetWarnings.push(audit.message);
         }
-        auditedCandidates.push(cand);
+        if (audit.hint === "promote") {
+          promotedCandidates.push(cand);
+          uviNotes.push(`${cand.label} promoted (UVI=${audit.uvi?.toFixed(2)} surplus)`);
+        } else if (audit.hint === "demote") {
+          demotedCandidates.push(cand);
+          uviNotes.push(`${cand.label} demoted (UVI=${audit.uvi?.toFixed(2)} stressed)`);
+        } else {
+          auditedCandidates.push(cand);
+        }
       }
 
-      const targets = auditedCandidates.length > 0
-        ? auditedCandidates
+      const orderedAudited = [...promotedCandidates, ...auditedCandidates, ...demotedCandidates];
+      const targets = orderedAudited.length > 0
+        ? orderedAudited
         : (solved.candidates.length > 0 ? solved.candidates : healthy);
       const constraintFallback = solved.candidates.length === 0 && solved.rejections.length > 0;
-      const budgetFallback = auditedCandidates.length === 0 && auditedRejections.length > 0;
+      const budgetFallback = orderedAudited.length === 0 && auditedRejections.length > 0;
 
       if (budgetWarnings.length > 0) {
         lastBudgetWarningByRoute.set(routeId, budgetWarnings.join(" | "));
@@ -802,6 +844,9 @@ function streamAutoRouter(model: Model<Api>, context: Context, options?: SimpleS
       }
       if (budgetWarnings.length > 0) {
         reasoningParts.push(`budget warning: ${budgetWarnings.join("; ")}`);
+      }
+      if (uviNotes.length > 0) {
+        reasoningParts.push(`uvi: ${uviNotes.join("; ")}`);
       }
       reasoningParts.push(`selected ${targets[0].label}`);
       const selectedLimit = budgetState.dailyLimit?.[targets[0].provider];
@@ -875,7 +920,17 @@ function getStatusLine(routeId?: string): string {
   const tierHint = decision ? ` | tier=${decision.tier} (${decision.metadata.confidence.toFixed(2)})` : "";
   const budgetWarning = lastBudgetWarningByRoute.get(routeId);
   const budgetText = budgetWarning ? ` | ⚠ ${budgetWarning}` : "";
-  return `auto-router ${getRouteName(routeId)}${tierHint} | ${active} | healthy: ${healthy.join(", ") || "none"} | ${formatCooldowns(routeId)}${budgetText}`;
+  const uviText = formatUviStatusSegment();
+  return `auto-router ${getRouteName(routeId)}${tierHint} | ${active} | healthy: ${healthy.join(", ") || "none"} | ${formatCooldowns(routeId)}${budgetText}${uviText}`;
+}
+
+function formatUviStatusSegment(): string {
+  if (!quotaCache.isEnabled()) return "";
+  const snaps = Object.values(quotaCache.getAllSnapshots());
+  const hot = snaps.filter((s) => s.status === "stressed" || s.status === "critical");
+  if (hot.length === 0) return "";
+  const parts = hot.map((s) => `${s.provider}=${s.uvi.toFixed(2)} ${s.status}`);
+  return ` | uvi: ${parts.join(", ")}`;
 }
 
 function refreshStatus(routeId?: string) {
@@ -1092,6 +1147,47 @@ export default function (pi: ExtensionAPI) {
         return;
       }
 
+      if (subcommand === "uvi") {
+        const [actionRaw] = remainder ? remainder.split(/\s+/) : [];
+        const action = String(actionRaw ?? "show").toLowerCase();
+        if (action === "enable") {
+          quotaCache.setEnabled(true);
+          ctx.ui.notify("UVI enabled. Background refresh will run on the next prompt (or use /auto-router uvi refresh).", "success");
+          return;
+        }
+        if (action === "disable") {
+          quotaCache.setEnabled(false);
+          budgetTracker.setUtilization({});
+          ctx.ui.notify("UVI disabled.", "info");
+          return;
+        }
+        if (action === "refresh") {
+          if (!quotaCache.isEnabled()) {
+            ctx.ui.notify("UVI is disabled. Enable it first with /auto-router uvi enable (or set AUTO_ROUTER_UVI=1).", "warning");
+            return;
+          }
+          ctx.ui.notify("Refreshing UVI snapshots...", "info");
+          await quotaCache.refreshNow();
+          syncUtilizationIntoBudget();
+          const lines = formatUtilizationLines(quotaCache);
+          ctx.ui.notify(lines.length > 0 ? ["UVI snapshot:", ...lines].join("\n") : "UVI: no snapshots (no OAuth providers found in auth.json?)", "info");
+          return;
+        }
+        // show (default)
+        const lines = formatUtilizationLines(quotaCache);
+        const status = quotaCache.isEnabled() ? "enabled" : "disabled";
+        const header = `UVI (${status}):`;
+        if (lines.length === 0) {
+          const hint = quotaCache.isEnabled()
+            ? "No snapshots yet. Try /auto-router uvi refresh."
+            : "Set AUTO_ROUTER_UVI=1 or run /auto-router uvi enable to start polling.";
+          ctx.ui.notify(`${header}\n  ${hint}`, "info");
+          return;
+        }
+        ctx.ui.notify([header, ...lines, "", "Subcommands: show | refresh | enable | disable"].join("\n"), "info");
+        return;
+      }
+
       if (subcommand === "budget") {
         await ensureBudgetLoaded();
         const [actionRaw, ...restArgs] = remainder ? remainder.split(/\s+/) : [];
@@ -1108,7 +1204,17 @@ export default function (pi: ExtensionAPI) {
             const ratio = typeof s.limitUsd === "number" && s.limitUsd > 0 ? ` (${Math.round((s.estimatedCost / s.limitUsd) * 100)}%)` : "";
             return `  ${s.provider.padEnd(22)} spend $${s.estimatedCost.toFixed(2)} | in ${s.inputTokens} | out ${s.outputTokens} | ${limitText}${ratio}`;
           });
-          ctx.ui.notify([`Auto-router budget for ${day}:`, ...lines, "", `Stats file: ${budgetTracker.getPath()}`].join("\n"), "info");
+          const uviLines = formatUtilizationLines(quotaCache);
+          const out = [`Auto-router budget for ${day}:`, ...lines];
+          if (uviLines.length > 0) {
+            out.push("", "UVI (utilization velocity):", ...uviLines);
+          } else if (quotaCache.isEnabled()) {
+            out.push("", "UVI: no snapshots yet (refreshing in background; try again shortly)");
+          } else {
+            out.push("", "UVI: disabled (set AUTO_ROUTER_UVI=1 to enable)");
+          }
+          out.push("", `Stats file: ${budgetTracker.getPath()}`);
+          ctx.ui.notify(out.join("\n"), "info");
           return;
         }
         if (action === "set") {

--- a/src/budget-auditor.ts
+++ b/src/budget-auditor.ts
@@ -1,4 +1,6 @@
-import type { BudgetState } from "./types.ts";
+import type { BudgetState, UVIStatus, UtilizationSnapshot } from "./types.ts";
+
+export type BudgetAuditHint = "promote" | "demote";
 
 export type BudgetAuditResult = {
   status: "ok" | "warning" | "blocked";
@@ -8,9 +10,13 @@ export type BudgetAuditResult = {
   remaining: number | null;
   usageRatio: number | null;
   message?: string;
+  uvi?: number;
+  utilizationStatus?: UVIStatus;
+  hint?: BudgetAuditHint;
+  utilizationReason?: string;
 };
 
-export function auditBudget(provider: string, budgetState: BudgetState | undefined, estimatedAdditionalUsd = 0): BudgetAuditResult {
+function auditUsd(provider: string, budgetState: BudgetState | undefined, estimatedAdditionalUsd: number): BudgetAuditResult {
   const spend = budgetState?.dailySpend?.[provider] ?? 0;
   const limit = budgetState?.dailyLimit?.[provider];
   if (!(typeof limit === "number") || !Number.isFinite(limit) || limit <= 0) {
@@ -46,4 +52,41 @@ export function auditBudget(provider: string, budgetState: BudgetState | undefin
   }
 
   return { status: "ok", provider, spend, limit, remaining, usageRatio };
+}
+
+function applyUtilization(base: BudgetAuditResult, util: UtilizationSnapshot | undefined, provider: string): BudgetAuditResult {
+  if (!util) return base;
+  const result: BudgetAuditResult = { ...base, uvi: util.uvi, utilizationStatus: util.status, utilizationReason: util.reason };
+
+  if (util.status === "critical") {
+    return {
+      ...result,
+      status: "blocked",
+      message: result.message ?? `${provider} UVI critical (${util.uvi.toFixed(2)}); ${util.reason}`,
+    };
+  }
+
+  if (util.status === "stressed") {
+    const message = `${provider} UVI stressed (${util.uvi.toFixed(2)}); ${util.reason}`;
+    if (result.status === "ok") {
+      return { ...result, status: "warning", hint: "demote", message };
+    }
+    return { ...result, hint: "demote", message: result.message ?? message };
+  }
+
+  if (util.status === "surplus") {
+    return { ...result, hint: "promote" };
+  }
+
+  return result;
+}
+
+export function auditBudget(
+  provider: string,
+  budgetState: BudgetState | undefined,
+  estimatedAdditionalUsd = 0,
+): BudgetAuditResult {
+  const base = auditUsd(provider, budgetState, estimatedAdditionalUsd);
+  const util = budgetState?.utilization?.[provider];
+  return applyUtilization(base, util, provider);
 }

--- a/src/budget-tracker.ts
+++ b/src/budget-tracker.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-import type { BudgetState } from "./types.ts";
+import type { BudgetState, UtilizationSnapshot } from "./types.ts";
 
 export const DEFAULT_STATS_PATH = join(homedir(), ".pi", "agent", "extensions", "auto-router.stats.json");
 
@@ -72,9 +72,18 @@ export class BudgetTracker {
   private stats: BudgetStatsFile = createDefaultStats();
   private loaded = false;
   private readonly path: string;
+  private utilization: Record<string, UtilizationSnapshot> = {};
 
   constructor(path = DEFAULT_STATS_PATH) {
     this.path = path;
+  }
+
+  setUtilization(snapshots: Record<string, UtilizationSnapshot>): void {
+    this.utilization = { ...snapshots };
+  }
+
+  getUtilization(): Record<string, UtilizationSnapshot> {
+    return this.utilization;
   }
 
   getPath(): string {
@@ -124,10 +133,12 @@ export class BudgetTracker {
   }
 
   getBudgetState(day = todayKey()): BudgetState {
-    return {
+    const state: BudgetState = {
       dailySpend: this.getDailySpend(day),
       dailyLimit: this.getDailyLimits(),
     };
+    if (Object.keys(this.utilization).length > 0) state.utilization = this.utilization;
+    return state;
   }
 
   getDailySummary(day = todayKey()): Array<{ provider: string; inputTokens: number; outputTokens: number; estimatedCost: number; limitUsd?: number }> {

--- a/src/quota-cache.ts
+++ b/src/quota-cache.ts
@@ -1,0 +1,171 @@
+import {
+  fetchAllUsages,
+  usageToWindows,
+  type FetchAllUsagesConfig,
+  type OAuthProviderId,
+  type UsageByProvider,
+} from "./quota-fetcher.ts";
+import { aggregateProviderUVI } from "./uvi.ts";
+import {
+  DEFAULT_UVI_THRESHOLDS,
+  type UVIThresholds,
+  type UtilizationSnapshot,
+} from "./types.ts";
+
+const OAUTH_PROVIDERS: OAuthProviderId[] = [
+  "openai-codex",
+  "anthropic",
+  "google-gemini-cli",
+  "google-antigravity",
+];
+
+// Maps the route-config `provider` field (and optional `authProvider`) to
+// the OAuth provider id used by the usage endpoints.
+const ROUTE_PROVIDER_TO_OAUTH: Record<string, OAuthProviderId> = {
+  "openai-codex": "openai-codex",
+  "google-antigravity": "google-antigravity",
+  "google-gemini-cli": "google-gemini-cli",
+  "anthropic": "anthropic",
+  "claude-agent-sdk": "anthropic",
+};
+
+export function mapRouteProviderToOAuth(
+  provider: string,
+  authProvider?: string,
+): OAuthProviderId | null {
+  if (authProvider && ROUTE_PROVIDER_TO_OAUTH[authProvider]) return ROUTE_PROVIDER_TO_OAUTH[authProvider];
+  if (provider && ROUTE_PROVIDER_TO_OAUTH[provider]) return ROUTE_PROVIDER_TO_OAUTH[provider];
+  return null;
+}
+
+export type QuotaCacheOptions = {
+  ttlMs?: number;
+  thresholds?: UVIThresholds;
+  fetchConfig?: FetchAllUsagesConfig;
+  enabled?: boolean;
+};
+
+const DEFAULT_TTL_MS = 60_000;
+const MIN_REFRESH_INTERVAL_MS = 30_000;
+
+export class QuotaCache {
+  private snapshots = new Map<OAuthProviderId, UtilizationSnapshot>();
+  private lastRefreshAt = 0;
+  private inflight: Promise<void> | null = null;
+  private ttlMs: number;
+  private thresholds: UVIThresholds;
+  private fetchConfig: FetchAllUsagesConfig;
+  private enabled: boolean;
+
+  constructor(opts: QuotaCacheOptions = {}) {
+    this.ttlMs = opts.ttlMs ?? envTtlMs() ?? DEFAULT_TTL_MS;
+    this.thresholds = opts.thresholds ?? DEFAULT_UVI_THRESHOLDS;
+    this.fetchConfig = opts.fetchConfig ?? {};
+    this.enabled = opts.enabled ?? envEnabled();
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  setEnabled(enabled: boolean): void {
+    this.enabled = enabled;
+  }
+
+  getSnapshot(oauthProvider: OAuthProviderId): UtilizationSnapshot | undefined {
+    return this.snapshots.get(oauthProvider);
+  }
+
+  getAllSnapshots(): Record<string, UtilizationSnapshot> {
+    return Object.fromEntries(this.snapshots.entries());
+  }
+
+  isStale(now = Date.now()): boolean {
+    if (this.lastRefreshAt === 0) return true;
+    return now - this.lastRefreshAt > this.ttlMs;
+  }
+
+  /** Trigger a background refresh if stale. Never throws, never blocks the caller. */
+  refreshIfStale(now = Date.now()): void {
+    if (!this.enabled) return;
+    if (this.inflight) return;
+    if (now - this.lastRefreshAt < MIN_REFRESH_INTERVAL_MS) return;
+    if (!this.isStale(now)) return;
+    this.inflight = this.refresh().finally(() => { this.inflight = null; });
+  }
+
+  /** Force a refresh now and wait for it. */
+  async refreshNow(): Promise<void> {
+    if (this.inflight) {
+      await this.inflight;
+      return;
+    }
+    this.inflight = this.refresh().finally(() => { this.inflight = null; });
+    await this.inflight;
+  }
+
+  private async refresh(): Promise<void> {
+    const now = Date.now();
+    let usages: UsageByProvider = {};
+    try {
+      usages = await fetchAllUsages(this.fetchConfig);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      for (const id of OAUTH_PROVIDERS) {
+        const prev = this.snapshots.get(id);
+        this.snapshots.set(id, {
+          provider: id,
+          uvi: prev?.uvi ?? 0,
+          status: prev?.status ?? "ok",
+          windows: prev?.windows ?? [],
+          reason: `fetch failed: ${msg}`,
+          error: msg,
+          stale: prev ? true : undefined,
+          fetchedAt: now,
+        });
+      }
+      this.lastRefreshAt = now;
+      return;
+    }
+
+    for (const id of OAUTH_PROVIDERS) {
+      const usage = usages[id];
+      if (!usage) {
+        // No auth or skipped; clear so we don't show stale data.
+        this.snapshots.delete(id);
+        continue;
+      }
+      if (usage.error) {
+        const prev = this.snapshots.get(id);
+        this.snapshots.set(id, {
+          provider: id,
+          uvi: prev?.uvi ?? 0,
+          status: prev?.status ?? "ok",
+          windows: prev?.windows ?? [],
+          reason: `usage fetch error: ${usage.error}`,
+          error: usage.error,
+          stale: prev ? true : undefined,
+          fetchedAt: now,
+        });
+        continue;
+      }
+      const windows = usageToWindows(id, usage);
+      const snap = aggregateProviderUVI(id, windows, now, this.thresholds);
+      this.snapshots.set(id, snap);
+    }
+    this.lastRefreshAt = now;
+  }
+}
+
+function envEnabled(): boolean {
+  const raw = process.env.AUTO_ROUTER_UVI;
+  if (!raw) return false;
+  return raw === "1" || raw.toLowerCase() === "true" || raw.toLowerCase() === "on";
+}
+
+function envTtlMs(): number | undefined {
+  const raw = process.env.AUTO_ROUTER_UVI_TTL_MS;
+  if (!raw) return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}

--- a/src/quota-fetcher.ts
+++ b/src/quota-fetcher.ts
@@ -1,0 +1,579 @@
+// Portions adapted from https://github.com/ajarellanod/pi-usage-bars
+// (extensions/usage-bars/core.ts) — fetches OAuth quota state from
+// Anthropic, OpenAI Codex, and Google (Gemini / Antigravity) usage endpoints.
+// Trimmed: no z.ai support, no UI helpers; adds QuotaWindow adapter.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import type { QuotaWindow } from "./types.ts";
+
+export type OAuthProviderId =
+  | "openai-codex"
+  | "anthropic"
+  | "google-gemini-cli"
+  | "google-antigravity";
+
+export interface AuthData {
+  "openai-codex"?: { access?: string; refresh?: string; expires?: number };
+  anthropic?: { access?: string; refresh?: string; expires?: number };
+  "google-gemini-cli"?: { access?: string; refresh?: string; projectId?: string; expires?: number };
+  "google-antigravity"?: { access?: string; refresh?: string; projectId?: string; expires?: number };
+}
+
+export interface UsageData {
+  session: number;
+  weekly: number;
+  sessionResetsIn?: string;
+  weeklyResetsIn?: string;
+  sessionResetsAt?: string;
+  weeklyResetsAt?: string;
+  sessionResetsInSec?: number;
+  weeklyResetsInSec?: number;
+  extraSpend?: number;
+  extraLimit?: number;
+  warning?: string;
+  stale?: boolean;
+  fetchedAt?: number;
+  error?: string;
+}
+
+export type UsageByProvider = Partial<Record<OAuthProviderId, UsageData | null>>;
+
+export interface UsageEndpoints {
+  gemini: string;
+  antigravity: string;
+  googleLoadCodeAssistEndpoints: string[];
+}
+
+export interface HeadersLike {
+  get(name: string): string | null;
+}
+
+export interface FetchResponseLike {
+  ok: boolean;
+  status: number;
+  headers?: HeadersLike;
+  json(): Promise<any>;
+}
+
+export type FetchLike = (input: string, init?: RequestInit) => Promise<FetchResponseLike>;
+
+export interface RequestConfig {
+  fetchFn?: FetchLike;
+  timeoutMs?: number;
+}
+
+export interface FetchConfig extends RequestConfig {
+  endpoints?: UsageEndpoints;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface OAuthApiKeyResult {
+  newCredentials: Record<string, any>;
+  apiKey: string;
+}
+
+export type OAuthApiKeyResolver = (
+  providerId: OAuthProviderId,
+  credentials: Record<string, Record<string, any>>,
+) => Promise<OAuthApiKeyResult | null>;
+
+export interface EnsureFreshAuthConfig {
+  auth?: AuthData | null;
+  authFile?: string;
+  oauthResolver?: OAuthApiKeyResolver;
+  nowMs?: number;
+  persist?: boolean;
+  forceRefreshProviders?: OAuthProviderId[];
+}
+
+export interface FreshAuthResult {
+  auth: AuthData | null;
+  changed: boolean;
+  refreshErrors: Partial<Record<OAuthProviderId, string>>;
+}
+
+export interface FetchAllUsagesConfig extends FetchConfig, EnsureFreshAuthConfig {
+  cacheFile?: string;
+}
+
+const DEFAULT_FETCH_TIMEOUT_MS = 12_000;
+const TOKEN_REFRESH_SKEW_MS = 60_000;
+const CLAUDE_SHARED_FRESH_TTL_MS = 2 * 60 * 1000;
+const CLAUDE_BASE_BACKOFF_MS = 2 * 60 * 1000;
+const CLAUDE_MAX_BACKOFF_MS = 30 * 60 * 1000;
+
+export const DEFAULT_AUTH_FILE = path.join(os.homedir(), ".pi", "agent", "auth.json");
+export const DEFAULT_USAGE_CACHE_FILE = path.join(os.tmpdir(), "pi", "auto-router-uvi-cache.json");
+export const GOOGLE_QUOTA_ENDPOINT = "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota";
+export const GOOGLE_LOAD_CODE_ASSIST_ENDPOINTS = [
+  "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist",
+  "https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:loadCodeAssist",
+];
+
+export const HOUR_MS = 60 * 60 * 1000;
+export const DAY_MS = 24 * HOUR_MS;
+export const CODEX_PRIMARY_WINDOW_MS = 5 * HOUR_MS;
+export const CODEX_SECONDARY_WINDOW_MS = 7 * DAY_MS;
+export const CLAUDE_FIVE_HOUR_WINDOW_MS = 5 * HOUR_MS;
+export const CLAUDE_SEVEN_DAY_WINDOW_MS = 7 * DAY_MS;
+// Google quota endpoint doesn't expose duration; assume daily resets.
+export const GOOGLE_DAILY_WINDOW_MS = DAY_MS;
+
+export function resolveUsageEndpoints(env: NodeJS.ProcessEnv = process.env): UsageEndpoints {
+  const configured = (value: string | undefined, fallback: string) => {
+    const trimmed = value?.trim();
+    return trimmed ? trimmed : fallback;
+  };
+
+  return {
+    gemini: configured(env.PI_GEMINI_USAGE_ENDPOINT, GOOGLE_QUOTA_ENDPOINT),
+    antigravity: configured(env.PI_ANTIGRAVITY_USAGE_ENDPOINT, GOOGLE_QUOTA_ENDPOINT),
+    googleLoadCodeAssistEndpoints: GOOGLE_LOAD_CODE_ASSIST_ENDPOINTS,
+  };
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    if (error.name === "AbortError") return "request timeout";
+    return error.message || String(error);
+  }
+  return String(error);
+}
+
+function asObject(value: unknown): Record<string, any> | null {
+  if (!value || typeof value !== "object") return null;
+  return value as Record<string, any>;
+}
+
+function getHeader(headers: HeadersLike | undefined, name: string): string | null {
+  if (!headers) return null;
+  try {
+    return headers.get(name);
+  } catch {
+    return null;
+  }
+}
+
+interface JsonRequestSuccess {
+  ok: true;
+  data: any;
+  status: number;
+  headers?: HeadersLike;
+}
+interface JsonRequestError {
+  ok: false;
+  error: string;
+  status: number | null;
+  headers?: HeadersLike;
+}
+type JsonRequestResult = JsonRequestSuccess | JsonRequestError;
+
+async function requestJson(url: string, init: RequestInit, config: RequestConfig = {}): Promise<JsonRequestResult> {
+  const fetchFn = config.fetchFn ?? ((fetch as unknown) as FetchLike);
+  const timeoutMs = config.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timeout = timeoutMs > 0 ? setTimeout(() => controller.abort(), timeoutMs) : null;
+
+  try {
+    const response = await fetchFn(url, { ...init, signal: controller.signal });
+    if (!response.ok) {
+      return { ok: false, error: `HTTP ${response.status}`, status: response.status, headers: response.headers };
+    }
+    try {
+      const data = await response.json();
+      return { ok: true, data, status: response.status, headers: response.headers };
+    } catch {
+      return { ok: false, error: "invalid JSON response", status: response.status, headers: response.headers };
+    }
+  } catch (error) {
+    return { ok: false, error: toErrorMessage(error), status: null };
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+export function parseRetryAfterMs(value: string | null | undefined, nowMs = Date.now()): number | null {
+  if (!value) return null;
+  const numeric = Number(value);
+  if (Number.isFinite(numeric) && numeric >= 0) return numeric * 1000;
+  const dateMs = new Date(value).getTime();
+  if (!Number.isFinite(dateMs)) return null;
+  return Math.max(0, dateMs - nowMs);
+}
+
+export function readAuth(authFile = DEFAULT_AUTH_FILE): AuthData | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(authFile, "utf-8"));
+    return asObject(parsed) as AuthData;
+  } catch {
+    return null;
+  }
+}
+
+export function writeAuth(auth: AuthData, authFile = DEFAULT_AUTH_FILE): boolean {
+  try {
+    const dir = path.dirname(authFile);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    const tmpPath = `${authFile}.tmp-${process.pid}-${Date.now()}`;
+    fs.writeFileSync(tmpPath, JSON.stringify(auth, null, 2));
+    fs.renameSync(tmpPath, authFile);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+let cachedOAuthResolver: OAuthApiKeyResolver | null = null;
+
+async function getDefaultOAuthResolver(): Promise<OAuthApiKeyResolver> {
+  if (cachedOAuthResolver) return cachedOAuthResolver;
+  const mod = await import("@mariozechner/pi-ai");
+  if (typeof (mod as any).getOAuthApiKey !== "function") {
+    throw new Error("oauth resolver unavailable");
+  }
+  cachedOAuthResolver = (providerId, credentials) =>
+    (mod as any).getOAuthApiKey(providerId, credentials) as Promise<OAuthApiKeyResult | null>;
+  return cachedOAuthResolver;
+}
+
+function isCredentialExpired(creds: { expires?: number } | undefined, nowMs: number): boolean {
+  if (!creds) return false;
+  if (typeof creds.expires !== "number") return false;
+  return nowMs + TOKEN_REFRESH_SKEW_MS >= creds.expires;
+}
+
+export async function ensureFreshAuthForProviders(
+  providerIds: OAuthProviderId[],
+  config: EnsureFreshAuthConfig = {},
+): Promise<FreshAuthResult> {
+  const authFile = config.authFile ?? DEFAULT_AUTH_FILE;
+  const auth = config.auth ?? readAuth(authFile);
+  if (!auth) return { auth: null, changed: false, refreshErrors: {} };
+
+  const nowMs = config.nowMs ?? Date.now();
+  const uniqueProviders = Array.from(new Set(providerIds));
+  const forcedProviders = new Set(config.forceRefreshProviders ?? []);
+  const nextAuth: AuthData = { ...auth };
+  const refreshErrors: Partial<Record<OAuthProviderId, string>> = {};
+  let changed = false;
+
+  for (const providerId of uniqueProviders) {
+    const creds = (nextAuth as any)[providerId] as { access?: string; refresh?: string; expires?: number } | undefined;
+    if (!creds?.refresh) continue;
+    const needsRefresh = forcedProviders.has(providerId) || !creds.access || isCredentialExpired(creds, nowMs);
+    if (!needsRefresh) continue;
+
+    try {
+      const resolver = config.oauthResolver ?? (await getDefaultOAuthResolver());
+      const resolved = await resolver(providerId, nextAuth as any);
+      if (!resolved?.newCredentials) {
+        refreshErrors[providerId] = "missing OAuth credentials";
+        continue;
+      }
+      (nextAuth as any)[providerId] = { ...(nextAuth as any)[providerId], ...resolved.newCredentials };
+      changed = true;
+    } catch (error) {
+      refreshErrors[providerId] = toErrorMessage(error);
+    }
+  }
+
+  if (changed && config.persist !== false) writeAuth(nextAuth, authFile);
+  return { auth: nextAuth, changed, refreshErrors };
+}
+
+export function readPercentCandidate(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  if (value >= 0 && value <= 1) {
+    if (Number.isInteger(value)) return value;
+    return value * 100;
+  }
+  if (value >= 0 && value <= 100) return value;
+  return null;
+}
+
+function usedPercentFromRemainingFraction(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  const remaining = Math.max(0, Math.min(1, value));
+  return (1 - remaining) * 100;
+}
+
+function pickMostUsedBucket(buckets: any[]): any | null {
+  let best: any | null = null;
+  let bestUsed = -1;
+  for (const bucket of buckets) {
+    const used = usedPercentFromRemainingFraction(bucket?.remainingFraction);
+    if (used == null) continue;
+    if (used > bestUsed) {
+      bestUsed = used;
+      best = bucket;
+    }
+  }
+  return best;
+}
+
+export function parseGoogleQuotaBuckets(
+  data: any,
+  provider: "gemini" | "antigravity",
+): { session: number; weekly: number } | null {
+  const allBuckets = Array.isArray(data?.buckets) ? data.buckets : [];
+  if (!allBuckets.length) return null;
+  const requestBuckets = allBuckets.filter((b: any) => String(b?.tokenType || "").toUpperCase() === "REQUESTS");
+  const buckets = requestBuckets.length ? requestBuckets : allBuckets;
+  const modelId = (b: any) => String(b?.modelId || "").toLowerCase();
+  const claudeNonThinking = buckets.filter((b: any) => modelId(b).includes("claude") && !modelId(b).includes("thinking"));
+  const geminiPro = buckets.filter((b: any) => modelId(b).includes("gemini") && modelId(b).includes("pro"));
+  const geminiFlash = buckets.filter((b: any) => modelId(b).includes("gemini") && modelId(b).includes("flash"));
+
+  const primaryBucket =
+    provider === "antigravity"
+      ? pickMostUsedBucket(claudeNonThinking) || pickMostUsedBucket(geminiPro) || pickMostUsedBucket(geminiFlash) || pickMostUsedBucket(buckets)
+      : pickMostUsedBucket(geminiPro) || pickMostUsedBucket(geminiFlash) || pickMostUsedBucket(buckets);
+  const secondaryBucket = pickMostUsedBucket(geminiFlash) || pickMostUsedBucket(geminiPro) || pickMostUsedBucket(buckets);
+  const session = usedPercentFromRemainingFraction(primaryBucket?.remainingFraction);
+  const weekly = usedPercentFromRemainingFraction(secondaryBucket?.remainingFraction);
+  if (session == null || weekly == null) return null;
+  return { session, weekly };
+}
+
+function googleMetadata(projectId?: string) {
+  return {
+    ideType: "IDE_UNSPECIFIED",
+    platform: "PLATFORM_UNSPECIFIED",
+    pluginType: "GEMINI",
+    ...(projectId ? { duetProject: projectId } : {}),
+  };
+}
+
+function googleHeaders(token: string, projectId?: string) {
+  return {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+    "User-Agent": "google-cloud-sdk vscode_cloudshelleditor/0.1",
+    "X-Goog-Api-Client": "gl-node/22.17.0",
+    "Client-Metadata": JSON.stringify(googleMetadata(projectId)),
+  };
+}
+
+export async function discoverGoogleProjectId(token: string, config: FetchConfig = {}): Promise<string | undefined> {
+  const env = config.env ?? process.env;
+  const envProjectId = env.GOOGLE_CLOUD_PROJECT || env.GOOGLE_CLOUD_PROJECT_ID;
+  if (envProjectId) return envProjectId;
+  const endpoints = config.endpoints ?? resolveUsageEndpoints(env);
+  for (const endpoint of endpoints.googleLoadCodeAssistEndpoints) {
+    const result = await requestJson(
+      endpoint,
+      { method: "POST", headers: googleHeaders(token), body: JSON.stringify({ metadata: googleMetadata() }) },
+      config,
+    );
+    if (!result.ok) continue;
+    const data = result.data;
+    if (typeof data?.cloudaicompanionProject === "string" && data.cloudaicompanionProject) return data.cloudaicompanionProject;
+    if (data?.cloudaicompanionProject && typeof data.cloudaicompanionProject === "object") {
+      const id = data.cloudaicompanionProject.id;
+      if (typeof id === "string" && id) return id;
+    }
+  }
+  return undefined;
+}
+
+export async function fetchCodexUsage(token: string, config: RequestConfig = {}): Promise<UsageData> {
+  const result = await requestJson(
+    "https://chatgpt.com/backend-api/wham/usage",
+    { headers: { Authorization: `Bearer ${token}` } },
+    config,
+  );
+  if (!result.ok) return { session: 0, weekly: 0, error: result.error };
+  const primary = result.data?.rate_limit?.primary_window;
+  const secondary = result.data?.rate_limit?.secondary_window;
+  const fetchedAt = Date.now();
+  return {
+    session: readPercentCandidate(primary?.used_percent) ?? 0,
+    weekly: readPercentCandidate(secondary?.used_percent) ?? 0,
+    sessionResetsInSec: typeof primary?.reset_after_seconds === "number" ? primary.reset_after_seconds : undefined,
+    weeklyResetsInSec: typeof secondary?.reset_after_seconds === "number" ? secondary.reset_after_seconds : undefined,
+    fetchedAt,
+  };
+}
+
+export async function fetchClaudeUsage(token: string, config: RequestConfig = {}): Promise<UsageData> {
+  const result = await requestJson(
+    "https://api.anthropic.com/api/oauth/usage",
+    { headers: { Authorization: `Bearer ${token}`, "anthropic-beta": "oauth-2025-04-20" } },
+    config,
+  );
+  const fetchedAt = Date.now();
+  if (!result.ok) {
+    const retryAfterMs = parseRetryAfterMs(getHeader(result.headers, "retry-after"), fetchedAt);
+    return {
+      session: 0,
+      weekly: 0,
+      error: result.error,
+      fetchedAt,
+      ...(retryAfterMs != null ? { sessionResetsInSec: Math.ceil(retryAfterMs / 1000) } : {}),
+    };
+  }
+  const data = result.data;
+  const usage: UsageData = {
+    session: readPercentCandidate(data?.five_hour?.utilization) ?? 0,
+    weekly: readPercentCandidate(data?.seven_day?.utilization) ?? 0,
+    sessionResetsAt: typeof data?.five_hour?.resets_at === "string" ? data.five_hour.resets_at : undefined,
+    weeklyResetsAt: typeof data?.seven_day?.resets_at === "string" ? data.seven_day.resets_at : undefined,
+    fetchedAt,
+  };
+  if (data?.extra_usage?.is_enabled) {
+    usage.extraSpend = typeof data.extra_usage.used_credits === "number" ? data.extra_usage.used_credits : undefined;
+    usage.extraLimit = typeof data.extra_usage.monthly_limit === "number" ? data.extra_usage.monthly_limit : undefined;
+  }
+  return usage;
+}
+
+export async function fetchGoogleUsage(
+  token: string,
+  endpoint: string,
+  projectId: string | undefined,
+  provider: "gemini" | "antigravity",
+  config: FetchConfig = {},
+): Promise<UsageData> {
+  if (!endpoint) return { session: 0, weekly: 0, error: "configure endpoint" };
+  const discoveredProjectId = projectId || (await discoverGoogleProjectId(token, config));
+  if (!discoveredProjectId) return { session: 0, weekly: 0, error: "missing projectId (try /login again)" };
+  const result = await requestJson(
+    endpoint,
+    { method: "POST", headers: googleHeaders(token, discoveredProjectId), body: JSON.stringify({ project: discoveredProjectId }) },
+    config,
+  );
+  const fetchedAt = Date.now();
+  if (!result.ok) return { session: 0, weekly: 0, error: result.error, fetchedAt };
+  const quota = parseGoogleQuotaBuckets(result.data, provider);
+  if (quota) return { ...quota, fetchedAt };
+  return { session: 0, weekly: 0, error: "unrecognized response shape", fetchedAt };
+}
+
+export async function fetchAllUsages(config: FetchAllUsagesConfig = {}): Promise<UsageByProvider> {
+  const authFile = config.authFile ?? DEFAULT_AUTH_FILE;
+  const auth = config.auth ?? readAuth(authFile);
+  const endpoints = config.endpoints ?? resolveUsageEndpoints(config.env);
+  const results: UsageByProvider = {};
+  if (!auth) return results;
+
+  const oauthProviders: OAuthProviderId[] = ["openai-codex", "anthropic", "google-gemini-cli", "google-antigravity"];
+  const refreshed = await ensureFreshAuthForProviders(oauthProviders, { ...config, auth, authFile });
+  const authData = refreshed.auth ?? auth;
+
+  const refreshError = (providerId: OAuthProviderId): string | null => {
+    const error = refreshed.refreshErrors[providerId];
+    return error ? `auth refresh failed (${error})` : null;
+  };
+
+  const tasks: Promise<void>[] = [];
+  const assign = (key: OAuthProviderId, task: Promise<UsageData>) => {
+    tasks.push(
+      task
+        .then((usage) => { results[key] = usage; })
+        .catch((error) => { results[key] = { session: 0, weekly: 0, error: toErrorMessage(error) }; }),
+    );
+  };
+
+  if (authData["openai-codex"]?.access) {
+    const err = refreshError("openai-codex");
+    if (err) results["openai-codex"] = { session: 0, weekly: 0, error: err };
+    else assign("openai-codex", fetchCodexUsage(authData["openai-codex"].access, config));
+  }
+
+  if (authData.anthropic?.access) {
+    const err = refreshError("anthropic");
+    if (err) results.anthropic = { session: 0, weekly: 0, error: err };
+    else assign("anthropic", fetchClaudeUsage(authData.anthropic.access, config));
+  }
+
+  if (authData["google-gemini-cli"]?.access) {
+    const err = refreshError("google-gemini-cli");
+    if (err) results["google-gemini-cli"] = { session: 0, weekly: 0, error: err };
+    else {
+      const creds = authData["google-gemini-cli"];
+      assign("google-gemini-cli", fetchGoogleUsage(creds.access!, endpoints.gemini, creds.projectId, "gemini", { ...config, endpoints }));
+    }
+  }
+
+  if (authData["google-antigravity"]?.access) {
+    const err = refreshError("google-antigravity");
+    if (err) results["google-antigravity"] = { session: 0, weekly: 0, error: err };
+    else {
+      const creds = authData["google-antigravity"];
+      assign("google-antigravity", fetchGoogleUsage(creds.access!, endpoints.antigravity, creds.projectId, "antigravity", { ...config, endpoints }));
+    }
+  }
+
+  await Promise.all(tasks);
+  return results;
+}
+
+// ─── Adapter: UsageData → QuotaWindow[] ───────────────────────────────────────
+
+export function usageToWindows(provider: OAuthProviderId, usage: UsageData | null | undefined): QuotaWindow[] {
+  if (!usage || usage.error) return [];
+  const fetchedAt = usage.fetchedAt ?? Date.now();
+  const source: QuotaWindow["source"] = usage.stale ? "stale-cache" : "oauth-usage";
+  const windows: QuotaWindow[] = [];
+
+  switch (provider) {
+    case "openai-codex": {
+      windows.push({
+        provider,
+        scope: "session",
+        usedPercent: usage.session,
+        resetsInSec: usage.sessionResetsInSec,
+        windowDurationMs: CODEX_PRIMARY_WINDOW_MS,
+        source,
+        fetchedAt,
+      });
+      windows.push({
+        provider,
+        scope: "weekly",
+        usedPercent: usage.weekly,
+        resetsInSec: usage.weeklyResetsInSec,
+        windowDurationMs: CODEX_SECONDARY_WINDOW_MS,
+        source,
+        fetchedAt,
+      });
+      break;
+    }
+    case "anthropic": {
+      windows.push({
+        provider,
+        scope: "session",
+        usedPercent: usage.session,
+        resetsAt: usage.sessionResetsAt,
+        windowDurationMs: CLAUDE_FIVE_HOUR_WINDOW_MS,
+        source,
+        fetchedAt,
+      });
+      windows.push({
+        provider,
+        scope: "weekly",
+        usedPercent: usage.weekly,
+        resetsAt: usage.weeklyResetsAt,
+        windowDurationMs: CLAUDE_SEVEN_DAY_WINDOW_MS,
+        source,
+        fetchedAt,
+      });
+      break;
+    }
+    case "google-gemini-cli":
+    case "google-antigravity": {
+      windows.push({
+        provider,
+        scope: "daily",
+        usedPercent: usage.session,
+        windowDurationMs: GOOGLE_DAILY_WINDOW_MS,
+        source,
+        fetchedAt,
+      });
+      break;
+    }
+  }
+
+  return windows;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,49 @@ export type Message = {
 export type BudgetState = {
   dailySpend: Record<string, number>;
   dailyLimit: Record<string, number>;
+  utilization?: Record<string, UtilizationSnapshot>;
+};
+
+export type QuotaScope = "session" | "weekly" | "monthly" | "daily";
+
+export type QuotaSource = "oauth-usage" | "stale-cache" | "config";
+
+export type QuotaWindow = {
+  provider: string;
+  scope: QuotaScope;
+  usedPercent: number;
+  resetsAt?: string;
+  resetsInSec?: number;
+  windowDurationMs: number;
+  source: QuotaSource;
+  fetchedAt: number;
+};
+
+export type UVIStatus = "ok" | "surplus" | "stressed" | "critical";
+
+export type UtilizationSnapshot = {
+  provider: string;
+  uvi: number;
+  status: UVIStatus;
+  windows: QuotaWindow[];
+  reason: string;
+  error?: string;
+  stale?: boolean;
+  fetchedAt: number;
+};
+
+export type UVIThresholds = {
+  stressed: number;
+  critical: number;
+  surplus: number;
+  surplusMinElapsed: number;
+};
+
+export const DEFAULT_UVI_THRESHOLDS: UVIThresholds = {
+  stressed: 1.5,
+  critical: 2.0,
+  surplus: 0.5,
+  surplusMinElapsed: 0.7,
 };
 
 export type RoutingDecision = {

--- a/src/uvi.ts
+++ b/src/uvi.ts
@@ -1,0 +1,97 @@
+import {
+  DEFAULT_UVI_THRESHOLDS,
+  type QuotaWindow,
+  type UVIStatus,
+  type UVIThresholds,
+  type UtilizationSnapshot,
+} from "./types.ts";
+
+const EPSILON = 0.05;
+
+export function computeElapsedFraction(window: QuotaWindow, now: number): number {
+  const duration = window.windowDurationMs;
+  if (!Number.isFinite(duration) || duration <= 0) return 0;
+
+  let remainingMs: number | null = null;
+  if (window.resetsAt) {
+    const resetMs = new Date(window.resetsAt).getTime();
+    if (Number.isFinite(resetMs)) remainingMs = resetMs - now;
+  }
+  if (remainingMs == null && typeof window.resetsInSec === "number" && Number.isFinite(window.resetsInSec)) {
+    remainingMs = (window.fetchedAt ? window.fetchedAt - now : 0) + window.resetsInSec * 1000;
+  }
+  if (remainingMs == null) return 0;
+
+  const clampedRemaining = Math.max(0, Math.min(duration, remainingMs));
+  return Math.max(0, Math.min(1, 1 - clampedRemaining / duration));
+}
+
+export function computeUVI(window: QuotaWindow, now: number): number {
+  const consumed = Math.max(0, Math.min(1, window.usedPercent / 100));
+  const elapsed = computeElapsedFraction(window, now);
+  const denom = Math.max(elapsed, EPSILON);
+  const uvi = consumed / denom;
+  return Number.isFinite(uvi) ? uvi : 0;
+}
+
+export function classifyUVI(
+  uvi: number,
+  elapsedFraction: number,
+  thresholds: UVIThresholds = DEFAULT_UVI_THRESHOLDS,
+): UVIStatus {
+  if (uvi >= thresholds.critical) return "critical";
+  if (uvi >= thresholds.stressed) return "stressed";
+  if (uvi <= thresholds.surplus && elapsedFraction >= thresholds.surplusMinElapsed) return "surplus";
+  return "ok";
+}
+
+function describeWindow(window: QuotaWindow): string {
+  const pct = `${window.usedPercent.toFixed(0)}%`;
+  return `${window.scope}@${pct}`;
+}
+
+export function aggregateProviderUVI(
+  provider: string,
+  windows: QuotaWindow[],
+  now: number,
+  thresholds: UVIThresholds = DEFAULT_UVI_THRESHOLDS,
+): UtilizationSnapshot {
+  if (!windows || windows.length === 0) {
+    return {
+      provider,
+      uvi: 0,
+      status: "ok",
+      windows: [],
+      reason: "no quota data",
+      fetchedAt: now,
+    };
+  }
+
+  let worstUvi = -Infinity;
+  let worstWindow: QuotaWindow | null = null;
+  let worstElapsed = 0;
+  for (const w of windows) {
+    const elapsed = computeElapsedFraction(w, now);
+    const uvi = computeUVI(w, now);
+    if (uvi > worstUvi) {
+      worstUvi = uvi;
+      worstWindow = w;
+      worstElapsed = elapsed;
+    }
+  }
+
+  const status = worstWindow ? classifyUVI(worstUvi, worstElapsed, thresholds) : "ok";
+  const summary = windows.map(describeWindow).join(", ");
+  const fetchedAt = Math.max(...windows.map((w) => w.fetchedAt || 0)) || now;
+  const stale = windows.some((w) => w.source === "stale-cache");
+
+  return {
+    provider,
+    uvi: Number.isFinite(worstUvi) ? Number(worstUvi.toFixed(3)) : 0,
+    status,
+    windows,
+    reason: `${status} (worst: ${worstWindow ? describeWindow(worstWindow) : "n/a"}; all: ${summary})`,
+    stale: stale || undefined,
+    fetchedAt,
+  };
+}

--- a/tests/budget-auditor.test.ts
+++ b/tests/budget-auditor.test.ts
@@ -1,6 +1,11 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { auditBudget } from "../src/budget-auditor.ts";
+import type { UVIStatus, UtilizationSnapshot } from "../src/types.ts";
+
+function snap(provider: string, status: UVIStatus, uvi: number): UtilizationSnapshot {
+  return { provider, status, uvi, windows: [], reason: `${status} (test)`, fetchedAt: 1 };
+}
 
 describe("auditBudget", () => {
   it("allows providers with no configured limit", () => {
@@ -30,5 +35,56 @@ describe("auditBudget", () => {
   it("uses projected spend when additional cost is provided", () => {
     const result = auditBudget("openai-codex", { dailySpend: { "openai-codex": 7.9 }, dailyLimit: { "openai-codex": 10 } }, 0.2);
     assert.equal(result.status, "warning");
+  });
+
+  it("blocks when UVI is critical even without USD limit", () => {
+    const result = auditBudget("anthropic", {
+      dailySpend: {},
+      dailyLimit: {},
+      utilization: { anthropic: snap("anthropic", "critical", 2.4) },
+    });
+    assert.equal(result.status, "blocked");
+    assert.equal(result.uvi, 2.4);
+    assert.equal(result.utilizationStatus, "critical");
+  });
+
+  it("warns and emits demote hint when UVI is stressed", () => {
+    const result = auditBudget("anthropic", {
+      dailySpend: {},
+      dailyLimit: {},
+      utilization: { anthropic: snap("anthropic", "stressed", 1.7) },
+    });
+    assert.equal(result.status, "warning");
+    assert.equal(result.hint, "demote");
+    assert.equal(result.utilizationStatus, "stressed");
+  });
+
+  it("emits promote hint when UVI is surplus", () => {
+    const result = auditBudget("openai-codex", {
+      dailySpend: {},
+      dailyLimit: {},
+      utilization: { "openai-codex": snap("openai-codex", "surplus", 0.3) },
+    });
+    assert.equal(result.status, "ok");
+    assert.equal(result.hint, "promote");
+    assert.equal(result.utilizationStatus, "surplus");
+  });
+
+  it("UVI critical overrides USD-ok status", () => {
+    const result = auditBudget("anthropic", {
+      dailySpend: { anthropic: 1 },
+      dailyLimit: { anthropic: 10 },
+      utilization: { anthropic: snap("anthropic", "critical", 2.5) },
+    });
+    assert.equal(result.status, "blocked");
+  });
+
+  it("USD blocked stays blocked with no UVI", () => {
+    const result = auditBudget("openai-codex", {
+      dailySpend: { "openai-codex": 10 },
+      dailyLimit: { "openai-codex": 10 },
+    });
+    assert.equal(result.status, "blocked");
+    assert.equal(result.hint, undefined);
   });
 });

--- a/tests/budget-tracker.test.ts
+++ b/tests/budget-tracker.test.ts
@@ -65,4 +65,25 @@ describe("BudgetTracker", () => {
     await tracker.clearDailyLimit("nvidia");
     assert.equal(tracker.getDailyLimits().nvidia, undefined);
   });
+
+  it("exposes utilization snapshots through getBudgetState", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "auto-router-budget-"));
+    const tracker = new BudgetTracker(join(dir, "stats.json"));
+    await tracker.load();
+    assert.equal(tracker.getBudgetState().utilization, undefined);
+    tracker.setUtilization({
+      anthropic: {
+        provider: "anthropic",
+        uvi: 1.7,
+        status: "stressed",
+        windows: [],
+        reason: "test",
+        fetchedAt: 1,
+      },
+    });
+    const state = tracker.getBudgetState();
+    assert.ok(state.utilization);
+    assert.equal(state.utilization!.anthropic.status, "stressed");
+    assert.equal(tracker.getUtilization().anthropic.uvi, 1.7);
+  });
 });

--- a/tests/quota-fetcher.test.ts
+++ b/tests/quota-fetcher.test.ts
@@ -1,0 +1,265 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  CLAUDE_FIVE_HOUR_WINDOW_MS,
+  CLAUDE_SEVEN_DAY_WINDOW_MS,
+  CODEX_PRIMARY_WINDOW_MS,
+  CODEX_SECONDARY_WINDOW_MS,
+  GOOGLE_DAILY_WINDOW_MS,
+  fetchAllUsages,
+  fetchClaudeUsage,
+  fetchCodexUsage,
+  fetchGoogleUsage,
+  parseGoogleQuotaBuckets,
+  parseRetryAfterMs,
+  readPercentCandidate,
+  usageToWindows,
+  type FetchLike,
+  type FetchResponseLike,
+} from "../src/quota-fetcher.ts";
+
+function mockResponse(body: any, init: { status?: number; ok?: boolean; headers?: Record<string, string> } = {}): FetchResponseLike {
+  const status = init.status ?? 200;
+  const ok = init.ok ?? (status >= 200 && status < 300);
+  const headers = init.headers ?? {};
+  return {
+    ok,
+    status,
+    headers: { get: (name: string) => headers[name.toLowerCase()] ?? headers[name] ?? null },
+    json: async () => body,
+  };
+}
+
+function mockFetch(map: Record<string, FetchResponseLike | ((url: string, init?: RequestInit) => FetchResponseLike)>): FetchLike {
+  return async (url, init) => {
+    for (const [pattern, response] of Object.entries(map)) {
+      if (url.includes(pattern)) {
+        return typeof response === "function" ? response(url, init) : response;
+      }
+    }
+    return mockResponse({ error: "no match" }, { status: 404, ok: false });
+  };
+}
+
+describe("readPercentCandidate", () => {
+  it("treats 0..1 floats as fractions", () => {
+    assert.equal(readPercentCandidate(0.42), 42);
+  });
+  it("treats integers 0..100 as percents", () => {
+    assert.equal(readPercentCandidate(72), 72);
+  });
+  it("rejects out-of-range values", () => {
+    assert.equal(readPercentCandidate(-5), null);
+    assert.equal(readPercentCandidate(150), null);
+  });
+});
+
+describe("parseRetryAfterMs", () => {
+  it("parses numeric seconds", () => {
+    assert.equal(parseRetryAfterMs("30", 0), 30_000);
+  });
+  it("parses HTTP date strings", () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const ms = parseRetryAfterMs(future, Date.now())!;
+    assert.ok(ms >= 59_000 && ms <= 61_000);
+  });
+  it("returns null for garbage", () => {
+    assert.equal(parseRetryAfterMs("nope"), null);
+  });
+});
+
+describe("parseGoogleQuotaBuckets", () => {
+  it("picks claude bucket first for antigravity", () => {
+    const data = {
+      buckets: [
+        { tokenType: "REQUESTS", modelId: "claude-3-5-sonnet", remainingFraction: 0.2 },
+        { tokenType: "REQUESTS", modelId: "gemini-pro", remainingFraction: 0.8 },
+        { tokenType: "REQUESTS", modelId: "gemini-flash", remainingFraction: 0.9 },
+      ],
+    };
+    const result = parseGoogleQuotaBuckets(data, "antigravity");
+    assert.ok(result);
+    // 1 - 0.2 = 0.8 → 80%
+    assert.equal(Math.round(result!.session), 80);
+  });
+
+  it("picks gemini-pro first for gemini provider", () => {
+    const data = {
+      buckets: [
+        { tokenType: "REQUESTS", modelId: "gemini-pro", remainingFraction: 0.5 },
+        { tokenType: "REQUESTS", modelId: "gemini-flash", remainingFraction: 0.7 },
+      ],
+    };
+    const result = parseGoogleQuotaBuckets(data, "gemini");
+    assert.ok(result);
+    assert.equal(Math.round(result!.session), 50);
+  });
+
+  it("returns null when no buckets present", () => {
+    assert.equal(parseGoogleQuotaBuckets({}, "gemini"), null);
+  });
+});
+
+describe("fetchCodexUsage", () => {
+  it("extracts both windows from rate_limit shape", async () => {
+    const fetchFn = mockFetch({
+      "/wham/usage": mockResponse({
+        rate_limit: {
+          primary_window: { used_percent: 35, reset_after_seconds: 3600 },
+          secondary_window: { used_percent: 12, reset_after_seconds: 86400 },
+        },
+      }),
+    });
+    const usage = await fetchCodexUsage("token", { fetchFn });
+    assert.equal(usage.session, 35);
+    assert.equal(usage.weekly, 12);
+    assert.equal(usage.sessionResetsInSec, 3600);
+    assert.equal(usage.weeklyResetsInSec, 86400);
+  });
+
+  it("surfaces fetch errors", async () => {
+    const fetchFn = mockFetch({
+      "/wham/usage": mockResponse({}, { status: 401, ok: false }),
+    });
+    const usage = await fetchCodexUsage("token", { fetchFn });
+    assert.match(usage.error ?? "", /HTTP 401/);
+  });
+});
+
+describe("fetchClaudeUsage", () => {
+  it("extracts five_hour and seven_day windows", async () => {
+    const sessionReset = new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString();
+    const weeklyReset = new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString();
+    const fetchFn = mockFetch({
+      "/api/oauth/usage": mockResponse({
+        five_hour: { utilization: 0.4, resets_at: sessionReset },
+        seven_day: { utilization: 0.18, resets_at: weeklyReset },
+      }),
+    });
+    const usage = await fetchClaudeUsage("token", { fetchFn });
+    assert.equal(usage.session, 40);
+    assert.equal(usage.weekly, 18);
+    assert.equal(usage.sessionResetsAt, sessionReset);
+    assert.equal(usage.weeklyResetsAt, weeklyReset);
+  });
+
+  it("captures retry-after on failures", async () => {
+    const fetchFn = mockFetch({
+      "/api/oauth/usage": mockResponse({}, { status: 429, ok: false, headers: { "retry-after": "120" } }),
+    });
+    const usage = await fetchClaudeUsage("token", { fetchFn });
+    assert.match(usage.error ?? "", /HTTP 429/);
+    assert.equal(usage.sessionResetsInSec, 120);
+  });
+});
+
+describe("fetchGoogleUsage", () => {
+  it("uses provided projectId and parses buckets", async () => {
+    const fetchFn = mockFetch({
+      ":retrieveUserQuota": mockResponse({
+        buckets: [
+          { tokenType: "REQUESTS", modelId: "gemini-2.5-pro", remainingFraction: 0.6 },
+          { tokenType: "REQUESTS", modelId: "gemini-2.5-flash", remainingFraction: 0.9 },
+        ],
+      }),
+    });
+    const usage = await fetchGoogleUsage("token", "https://x/:retrieveUserQuota", "proj-1", "gemini", { fetchFn });
+    assert.equal(usage.error, undefined);
+    assert.equal(Math.round(usage.session), 40);
+  });
+
+  it("returns error when projectId discovery fails", async () => {
+    const fetchFn = mockFetch({});
+    const usage = await fetchGoogleUsage("token", "https://x/:retrieveUserQuota", undefined, "gemini", {
+      fetchFn,
+      env: {},
+    });
+    assert.match(usage.error ?? "", /missing projectId|HTTP 404/);
+  });
+});
+
+describe("fetchAllUsages", () => {
+  it("only fetches providers present in auth", async () => {
+    let codexCalls = 0;
+    let anthropicCalls = 0;
+    const fetchFn: FetchLike = async (url) => {
+      if (url.includes("/wham/usage")) {
+        codexCalls++;
+        return mockResponse({ rate_limit: { primary_window: { used_percent: 10 }, secondary_window: { used_percent: 5 } } });
+      }
+      if (url.includes("/api/oauth/usage")) {
+        anthropicCalls++;
+        return mockResponse({ five_hour: { utilization: 0.3 }, seven_day: { utilization: 0.1 } });
+      }
+      return mockResponse({}, { status: 404, ok: false });
+    };
+    const result = await fetchAllUsages({
+      auth: { "openai-codex": { access: "x" } },
+      fetchFn,
+    });
+    assert.equal(codexCalls, 1);
+    assert.equal(anthropicCalls, 0);
+    assert.ok(result["openai-codex"]);
+    assert.equal(result.anthropic, undefined);
+  });
+});
+
+describe("usageToWindows", () => {
+  it("emits two windows for codex with reset seconds", () => {
+    const windows = usageToWindows("openai-codex", {
+      session: 25,
+      weekly: 10,
+      sessionResetsInSec: 3600,
+      weeklyResetsInSec: 86400,
+      fetchedAt: 1_700_000_000_000,
+    });
+    assert.equal(windows.length, 2);
+    assert.equal(windows[0].scope, "session");
+    assert.equal(windows[0].windowDurationMs, CODEX_PRIMARY_WINDOW_MS);
+    assert.equal(windows[1].scope, "weekly");
+    assert.equal(windows[1].windowDurationMs, CODEX_SECONDARY_WINDOW_MS);
+  });
+
+  it("emits two windows for anthropic with reset timestamps", () => {
+    const sessionReset = new Date(1_700_000_000_000 + 3 * 60 * 60 * 1000).toISOString();
+    const weeklyReset = new Date(1_700_000_000_000 + 5 * 24 * 60 * 60 * 1000).toISOString();
+    const windows = usageToWindows("anthropic", {
+      session: 60,
+      weekly: 25,
+      sessionResetsAt: sessionReset,
+      weeklyResetsAt: weeklyReset,
+      fetchedAt: 1_700_000_000_000,
+    });
+    assert.equal(windows.length, 2);
+    assert.equal(windows[0].windowDurationMs, CLAUDE_FIVE_HOUR_WINDOW_MS);
+    assert.equal(windows[1].windowDurationMs, CLAUDE_SEVEN_DAY_WINDOW_MS);
+    assert.equal(windows[0].resetsAt, sessionReset);
+  });
+
+  it("emits a single daily window for google providers", () => {
+    const windows = usageToWindows("google-antigravity", {
+      session: 40,
+      weekly: 50,
+      fetchedAt: 1_700_000_000_000,
+    });
+    assert.equal(windows.length, 1);
+    assert.equal(windows[0].scope, "daily");
+    assert.equal(windows[0].windowDurationMs, GOOGLE_DAILY_WINDOW_MS);
+    assert.equal(windows[0].usedPercent, 40);
+  });
+
+  it("returns empty when usage is missing or errored", () => {
+    assert.equal(usageToWindows("anthropic", null).length, 0);
+    assert.equal(usageToWindows("anthropic", { session: 0, weekly: 0, error: "boom" }).length, 0);
+  });
+
+  it("marks source as stale-cache when usage is stale", () => {
+    const windows = usageToWindows("openai-codex", {
+      session: 10,
+      weekly: 5,
+      stale: true,
+      fetchedAt: 1_700_000_000_000,
+    });
+    assert.equal(windows[0].source, "stale-cache");
+  });
+});

--- a/tests/uvi.test.ts
+++ b/tests/uvi.test.ts
@@ -1,0 +1,155 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  aggregateProviderUVI,
+  classifyUVI,
+  computeElapsedFraction,
+  computeUVI,
+} from "../src/uvi.ts";
+import { DEFAULT_UVI_THRESHOLDS, type QuotaWindow } from "../src/types.ts";
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+function makeWindow(overrides: Partial<QuotaWindow> = {}): QuotaWindow {
+  const now = 1_700_000_000_000;
+  return {
+    provider: "anthropic",
+    scope: "session",
+    usedPercent: 50,
+    windowDurationMs: 5 * HOUR,
+    resetsAt: new Date(now + 2.5 * HOUR).toISOString(),
+    source: "oauth-usage",
+    fetchedAt: now,
+    ...overrides,
+  };
+}
+
+describe("computeElapsedFraction", () => {
+  it("returns 0.5 when half the window remains", () => {
+    const now = 1_700_000_000_000;
+    const w = makeWindow({ resetsAt: new Date(now + 2.5 * HOUR).toISOString() });
+    assert.equal(computeElapsedFraction(w, now), 0.5);
+  });
+
+  it("returns 1 when reset time has passed", () => {
+    const now = 1_700_000_000_000;
+    const w = makeWindow({ resetsAt: new Date(now - HOUR).toISOString() });
+    assert.equal(computeElapsedFraction(w, now), 1);
+  });
+
+  it("returns 0 when full window remaining", () => {
+    const now = 1_700_000_000_000;
+    const w = makeWindow({ resetsAt: new Date(now + 5 * HOUR).toISOString() });
+    assert.equal(computeElapsedFraction(w, now), 0);
+  });
+
+  it("uses resetsInSec when resetsAt missing", () => {
+    const now = 1_700_000_000_000;
+    const w = makeWindow({
+      resetsAt: undefined,
+      resetsInSec: 2.5 * 60 * 60,
+      fetchedAt: now,
+    });
+    assert.equal(computeElapsedFraction(w, now), 0.5);
+  });
+
+  it("returns 0 when no reset info", () => {
+    const w = makeWindow({ resetsAt: undefined, resetsInSec: undefined });
+    assert.equal(computeElapsedFraction(w, 1_700_000_000_000), 0);
+  });
+});
+
+describe("computeUVI", () => {
+  it("returns ~1.0 when on-pace (50% used at 50% elapsed)", () => {
+    const now = 1_700_000_000_000;
+    const w = makeWindow({ usedPercent: 50, resetsAt: new Date(now + 2.5 * HOUR).toISOString() });
+    assert.equal(computeUVI(w, now), 1);
+  });
+
+  it("returns >1.5 when burning fast (75% used at 25% elapsed)", () => {
+    const now = 1_700_000_000_000;
+    const w = makeWindow({
+      usedPercent: 75,
+      resetsAt: new Date(now + 3.75 * HOUR).toISOString(),
+    });
+    const uvi = computeUVI(w, now);
+    assert.ok(uvi >= 3, `expected high UVI, got ${uvi}`);
+  });
+
+  it("returns <1 when underutilized", () => {
+    const now = 1_700_000_000_000;
+    const w = makeWindow({ usedPercent: 10, resetsAt: new Date(now + 0.5 * HOUR).toISOString() });
+    assert.ok(computeUVI(w, now) < 1);
+  });
+
+  it("clamps elapsed via epsilon to avoid div-by-zero at window start", () => {
+    const now = 1_700_000_000_000;
+    const w = makeWindow({ usedPercent: 1, resetsAt: new Date(now + 5 * HOUR).toISOString() });
+    const uvi = computeUVI(w, now);
+    assert.ok(Number.isFinite(uvi));
+    assert.ok(uvi > 0 && uvi < 1);
+  });
+});
+
+describe("classifyUVI", () => {
+  it("flags critical above the critical threshold", () => {
+    assert.equal(classifyUVI(2.5, 0.3), "critical");
+  });
+
+  it("flags stressed between stressed and critical", () => {
+    assert.equal(classifyUVI(1.7, 0.3), "stressed");
+  });
+
+  it("flags surplus only when elapsed past surplusMinElapsed", () => {
+    assert.equal(classifyUVI(0.3, 0.8), "surplus");
+    assert.equal(classifyUVI(0.3, 0.4), "ok");
+  });
+
+  it("returns ok in the normal band", () => {
+    assert.equal(classifyUVI(0.9, 0.5), "ok");
+  });
+
+  it("respects custom thresholds", () => {
+    const t = { stressed: 1.2, critical: 1.5, surplus: 0.8, surplusMinElapsed: 0.5 };
+    assert.equal(classifyUVI(1.3, 0.4, t), "stressed");
+    assert.equal(classifyUVI(1.6, 0.4, t), "critical");
+    assert.equal(classifyUVI(0.5, 0.6, t), "surplus");
+  });
+});
+
+describe("aggregateProviderUVI", () => {
+  it("returns ok with empty windows", () => {
+    const snap = aggregateProviderUVI("anthropic", [], 1_700_000_000_000);
+    assert.equal(snap.status, "ok");
+    assert.equal(snap.uvi, 0);
+    assert.match(snap.reason, /no quota data/);
+  });
+
+  it("uses the worst window", () => {
+    const now = 1_700_000_000_000;
+    const sessionWindow = makeWindow({
+      scope: "session",
+      usedPercent: 80,
+      windowDurationMs: 5 * HOUR,
+      resetsAt: new Date(now + 4 * HOUR).toISOString(),
+    });
+    const weeklyWindow = makeWindow({
+      scope: "weekly",
+      usedPercent: 30,
+      windowDurationMs: 7 * DAY,
+      resetsAt: new Date(now + 3 * DAY).toISOString(),
+    });
+    const snap = aggregateProviderUVI("anthropic", [sessionWindow, weeklyWindow], now);
+    assert.equal(snap.status, "critical");
+    assert.ok(snap.uvi >= DEFAULT_UVI_THRESHOLDS.critical);
+    assert.match(snap.reason, /session@80%/);
+  });
+
+  it("marks snapshot stale when any window is stale-cache", () => {
+    const now = 1_700_000_000_000;
+    const w = makeWindow({ source: "stale-cache" });
+    const snap = aggregateProviderUVI("anthropic", [w], now);
+    assert.equal(snap.stale, true);
+  });
+});


### PR DESCRIPTION
## Summary
Implements Phase 7 UVI from `PROPOSAL.md`: real-time quota pressure sensing for OAuth subscription providers (Anthropic, OpenAI Codex, Google Gemini, Google Antigravity) with selector-side promote/demote hints.

- **UVI math** (`src/uvi.ts`): `UVI = consumed_fraction / elapsed_fraction_of_window`, worst-window aggregation per provider.
- **Quota fetcher** (`src/quota-fetcher.ts`): vendored from [ajarellanod/pi-usage-bars](https://github.com/ajarellanod/pi-usage-bars) (trimmed); calls each provider's OAuth usage endpoint and adapts `UsageData` to `QuotaWindow[]`.
- **Quota cache** (`src/quota-cache.ts`): TTL-bounded async refresh, route-provider to OAuth-provider mapping (e.g. `claude-agent-sdk` -> `anthropic`).
- **Auditor + selector**: `auditBudget` now emits `promote`/`demote` hints; `streamAutoRouter` partitions candidates into `[promoted, normal, demoted]` and tries them in that order. `critical` -> blocked, `stressed` -> warning+demote, `surplus` (uvi <= 0.5 with elapsed >= 0.7) -> promote.
- **UI**: `/auto-router uvi [show|refresh|enable|disable]`, UVI block in `/auto-router budget`, `uvi:` segment in the status line when any provider is stressed/critical, UVI notes in `/auto-router explain` reasoning.

### Behavior
- **Off by default.** Opt in with `AUTO_ROUTER_UVI=1` or `/auto-router uvi enable`.
- TTL configurable via `AUTO_ROUTER_UVI_TTL_MS` (default 60s).
- Refresh is async, never blocks a prompt.
- UVI augments static USD limits; does not replace them.

## Test plan
- [x] `npm test` - 97/97 tests pass (16 new UVI math tests, 17 new quota-fetcher tests with mocked fetch, +6 auditor/tracker tests for utilization).
- [ ] Manual: enable with `AUTO_ROUTER_UVI=1`, run `/auto-router uvi refresh`, confirm snapshots populate from real OAuth endpoints.
- [ ] Manual: verify `/auto-router budget` shows the UVI block and `/auto-router explain` includes promote/demote notes after a routed prompt.
- [ ] Manual: regression - disabled (default) path matches prior failover behavior on all 5 route chains.

## Deferred
- Performance-based ranking, intent classification, proactive provider health checks, user feedback loop (other Phase 7 bullets).
- Hard-override env flag for surplus-driven promotion (currently tiebreaker only via partition order).
- Integration test for end-to-end selector ordering through `streamAutoRouter` (unit-level hint emission is covered).
