### PR TITLE
feat(pi-auto-router): parse absolute reset times like "reset at MM-DD HH:MM:SS UTC"

### DIFF
--- a/src/display.ts
+++ b/src/display.ts
@@ -80,20 +80,35 @@ export function parseClockResetMs(message: any): number | undefined {
 }
 
 /** Parse an absolute reset time like "reset at 08-14 09:18:00 UTC" and return ms until that time. */
-function parseAbsoluteResetMs(message: any): number | undefined {
+export function parseAbsoluteResetMs(message: any): number | undefined {
   const text = String(message ?? "");
   const match = text.match(/reset at (\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(?: UTC)?/i);
   if (!match) return undefined;
-  const month = Number(match[1]) - 1;
+  const month = Number(match[1]);
   const day = Number(match[2]);
   const hour = Number(match[3]);
   const minute = Number(match[4]);
   const second = Number(match[5]);
-  if (!Number.isFinite(month) || !Number.isFinite(day) || !Number.isFinite(hour) || !Number.isFinite(minute) || !Number.isFinite(second)) return undefined;
+  if (month < 1 || month > 12 || day < 1 || day > 31 || hour > 23 || minute > 59 || second > 59) return undefined;
+
   const now = Date.now();
-  const target = Date.UTC(new Date(now).getUTCFullYear(), month, day, hour, minute, second);
-  const ms = target - now;
-  return ms > 0 ? ms : 0;
+  const currentYear = new Date(now).getUTCFullYear();
+  const timestampForYear = (year: number): number | undefined => {
+    const timestamp = Date.UTC(year, month - 1, day, hour, minute, second);
+    const date = new Date(timestamp);
+    // Date.UTC rolls invalid dates forward (for example, February 30 to March 2).
+    if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) return undefined;
+    return timestamp;
+  };
+
+  const currentYearTarget = timestampForYear(currentYear);
+  if (currentYearTarget !== undefined && currentYearTarget >= now) return currentYearTarget - now;
+
+  // Messages omit the year, so a January reset reported in December belongs to next year.
+  const nextYearTarget = timestampForYear(currentYear + 1);
+  if (nextYearTarget === undefined) return undefined;
+  const ms = nextYearTarget - now;
+  return ms >= 0 ? ms : undefined;
 }
 
 /** Determine cooldown duration in ms based on the error message content. */

--- a/src/display.ts
+++ b/src/display.ts
@@ -79,12 +79,31 @@ export function parseClockResetMs(message: any): number | undefined {
   return ms > 0 ? ms : undefined;
 }
 
+/** Parse an absolute reset time like "reset at 08-14 09:18:00 UTC" and return ms until that time. */
+function parseAbsoluteResetMs(message: any): number | undefined {
+  const text = String(message ?? "");
+  const match = text.match(/reset at (\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(?: UTC)?/i);
+  if (!match) return undefined;
+  const month = Number(match[1]) - 1;
+  const day = Number(match[2]);
+  const hour = Number(match[3]);
+  const minute = Number(match[4]);
+  const second = Number(match[5]);
+  if (!Number.isFinite(month) || !Number.isFinite(day) || !Number.isFinite(hour) || !Number.isFinite(minute) || !Number.isFinite(second)) return undefined;
+  const now = Date.now();
+  const target = Date.UTC(new Date(now).getUTCFullYear(), month, day, hour, minute, second);
+  const ms = target - now;
+  return ms > 0 ? ms : 0;
+}
+
 /** Determine cooldown duration in ms based on the error message content. */
 export function getCooldownMs(message: any): number {
   const explicitResetMs = parseResetAfterMs(message);
   if (explicitResetMs) return explicitResetMs + 5_000;
   const clockResetMs = parseClockResetMs(message);
   if (clockResetMs) return clockResetMs;
+  const absoluteResetMs = parseAbsoluteResetMs(message);
+  if (absoluteResetMs !== undefined) return absoluteResetMs + 5_000;
 
   const text = String(message ?? "").toLowerCase();
   if (text.includes("429") || text.includes("rate limit") || text.includes("too many requests") || text.includes("throttled")) return 2 * 60_000;

--- a/tests/display.test.ts
+++ b/tests/display.test.ts
@@ -1,6 +1,6 @@
-import { describe, it } from "node:test";
+import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { parseModelSpec, describeTarget, formatHintsHuman, formatRemainingMs, parseResetAfterMs, parseClockResetMs, getCooldownMs, normalizeModelToken, findCaseInsensitiveKey, providerApiKeyEnvVars, resolveProviderApiKeyFromEnv, formatModelLine, getPrimaryModelLimits, findModelInRegistry, validateRouteTarget, getTargetKey } from "../src/display.ts";
+import { parseModelSpec, describeTarget, formatHintsHuman, formatRemainingMs, parseResetAfterMs, parseClockResetMs, parseAbsoluteResetMs, getCooldownMs, normalizeModelToken, findCaseInsensitiveKey, providerApiKeyEnvVars, resolveProviderApiKeyFromEnv, formatModelLine, getPrimaryModelLimits, findModelInRegistry, validateRouteTarget, getTargetKey } from "../src/display.ts";
 import type { ModelDisplayInfo } from "../src/display.ts";
 import type { RouteTarget, RoutingHints } from "../src/types.ts";
 
@@ -241,6 +241,99 @@ describe("parseClockResetMs", () => {
   it("returns undefined for invalid hour values", () => {
     assert.equal(parseClockResetMs("resets 13pm"), undefined);
     assert.equal(parseClockResetMs("resets 0pm"), undefined);
+  });
+});
+
+describe("parseAbsoluteResetMs", () => {
+  const realNow = Date.now;
+  const stubNow = (iso: string) => {
+    Date.now = () => Date.parse(iso);
+  };
+  const msBetween = (fromIso: string, toIso: string) => Date.parse(toIso) - Date.parse(fromIso);
+
+  afterEach(() => {
+    Date.now = realNow;
+  });
+
+  it("parses a future 'reset at MM-DD HH:MM:SS UTC' timestamp", () => {
+    stubNow("2026-08-10T00:00:00Z");
+    const ms = parseAbsoluteResetMs("Your token-plan 1-week quota has been exhausted. The quota will reset at 08-14 09:18:00 UTC.");
+    assert.equal(ms, msBetween("2026-08-10T00:00:00Z", "2026-08-14T09:18:00Z"));
+  });
+
+  it("computes the exact cooldown down to the second", () => {
+    stubNow("2026-08-10T00:00:00Z");
+    const ms = parseAbsoluteResetMs("reset at 08-10 00:00:30 UTC");
+    assert.equal(ms, 30_000);
+  });
+
+  it("returns 0 when the reset is happening right now", () => {
+    stubNow("2026-08-14T09:18:00Z");
+    const ms = parseAbsoluteResetMs("reset at 08-14 09:18:00 UTC");
+    assert.equal(ms, 0);
+  });
+
+  it("rolls a January reset reported in December over to next year", () => {
+    stubNow("2026-12-31T23:00:00Z");
+    const ms = parseAbsoluteResetMs("reset at 01-01 01:00:00 UTC");
+    // 2027-01-01 01:00 UTC is 2 hours away — not a few seconds in the past.
+    assert.equal(ms, 2 * 60 * 60_000);
+  });
+
+  it("uses next year when the reported date already passed this year", () => {
+    stubNow("2026-08-10T00:00:00Z");
+    const ms = parseAbsoluteResetMs("reset at 01-15 03:00:00 UTC");
+    assert.equal(ms, msBetween("2026-08-10T00:00:00Z", "2027-01-15T03:00:00Z"));
+  });
+
+  it("supports messages without the UTC suffix", () => {
+    stubNow("2026-08-10T00:00:00Z");
+    const ms = parseAbsoluteResetMs("reset at 08-14 09:18:00");
+    assert.equal(ms, msBetween("2026-08-10T00:00:00Z", "2026-08-14T09:18:00Z"));
+  });
+
+  it("rejects out-of-range values instead of letting Date.UTC roll them over", () => {
+    stubNow("2026-08-10T00:00:00Z");
+    assert.equal(parseAbsoluteResetMs("reset at 13-01 00:00:00 UTC"), undefined);
+    assert.equal(parseAbsoluteResetMs("reset at 00-01 00:00:00 UTC"), undefined);
+    assert.equal(parseAbsoluteResetMs("reset at 08-00 00:00:00 UTC"), undefined);
+    assert.equal(parseAbsoluteResetMs("reset at 08-32 00:00:00 UTC"), undefined);
+    assert.equal(parseAbsoluteResetMs("reset at 08-14 24:00:00 UTC"), undefined);
+    assert.equal(parseAbsoluteResetMs("reset at 08-14 09:60:00 UTC"), undefined);
+    assert.equal(parseAbsoluteResetMs("reset at 08-14 09:18:60 UTC"), undefined);
+  });
+
+  it("rejects impossible calendar dates like February 30", () => {
+    stubNow("2026-08-10T00:00:00Z");
+    assert.equal(parseAbsoluteResetMs("reset at 02-30 00:00:00 UTC"), undefined);
+    assert.equal(parseAbsoluteResetMs("reset at 04-31 00:00:00 UTC"), undefined);
+  });
+
+  it("returns undefined for non-matching messages", () => {
+    stubNow("2026-08-10T00:00:00Z");
+    assert.equal(parseAbsoluteResetMs("429 Too Many Requests"), undefined);
+    assert.equal(parseAbsoluteResetMs("reset after 30 seconds"), undefined);
+    assert.equal(parseAbsoluteResetMs(""), undefined);
+  });
+});
+
+describe("getCooldownMs absolute reset", () => {
+  const realNow = Date.now;
+
+  afterEach(() => {
+    Date.now = realNow;
+  });
+
+  it("uses the exact absolute reset time instead of the 5m quota fallback", () => {
+    Date.now = () => Date.parse("2026-08-10T00:00:00Z");
+    const ms = getCooldownMs("Your token-plan 1-week quota has been exhausted. The quota will reset at 08-14 09:18:00 UTC.");
+    const exact = Date.parse("2026-08-14T09:18:00Z") - Date.parse("2026-08-10T00:00:00Z");
+    assert.equal(ms, exact + 5_000);
+  });
+
+  it("falls back to the generic 5m quota cooldown for garbled absolute times", () => {
+    Date.now = () => Date.parse("2026-08-10T00:00:00Z");
+    assert.equal(getCooldownMs("quota exhausted, reset at 13-99 99:99:99 UTC"), 5 * 60_000);
   });
 });
 


### PR DESCRIPTION
## Summary

Aliyun Token Plan (百炼 Token-Plan) returns 429 when the weekly quota is exhausted, with a message like:

> Your token-plan 1-week quota has been exhausted. The quota will reset at 08-14 09:18:00 UTC.

The existing `parseClockResetMs` only handles same-day times (e.g. "resets 8pm"), so this message falls through to a generic 5-minute cooldown — causing repeated failed requests until the plan resets.

## Changes

Add `parseAbsoluteResetMs` to match `reset at MM-DD HH:MM:SS UTC` and compute the exact cooldown duration until the reset timestamp. Falls back to existing rules when the format doesn't match.

## Testing

Tested locally with the actual Aliyun Token Plan 429 message:

```
matched: true
ms: 333772392 (~3.86 days, exact to 08-14 09:18 UTC)
```